### PR TITLE
ci: add github actions security gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+name: OperCerta CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repository-safety:
+    name: repository-safety
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Verify repository safety
+        run: python scripts/verify_repository_safety.py
+
+  python-quality:
+    name: python-quality
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install frozen Python dependencies
+        run: uv sync --frozen --all-groups
+      - name: Run Ruff
+        run: uv run ruff check .
+      - name: Check Ruff formatting
+        run: uv run ruff format --check .
+      - name: Run mypy
+        run: uv run mypy src
+
+  backend-tests:
+    name: backend-tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: opercerta_ci
+          POSTGRES_PASSWORD: opercerta_ci_only
+          POSTGRES_DB: opercerta_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U opercerta_ci -d opercerta_ci"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+    env:
+      OPERCERTA_DATABASE_URL: postgresql+psycopg://opercerta_ci@127.0.0.1:5432/opercerta_ci
+      PGPASSWORD: opercerta_ci_only
+      LANGGRAPH_STRICT_MSGPACK: "true"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.28"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install frozen Python dependencies
+        run: uv sync --frozen --all-groups
+      - name: Run complete backend tests
+        run: uv run pytest -q
+
+  frontend:
+    name: frontend
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install frozen frontend dependencies
+        run: npm ci
+      - name: Run frontend tests
+        run: npm run test:run
+      - name: Build frontend
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,39 @@ jobs:
         run: npm run test:run
       - name: Build frontend
         run: npm run build
+
+  compose-smoke:
+    name: compose-smoke
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    needs: [repository-safety, python-quality, backend-tests, frontend]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Create isolated Compose environment
+        shell: bash
+        run: |
+          cp .env.compose.example .env.compose
+          sed -i 's/CHANGE_ME_DEVELOPMENT_ONLY/ci-only-signing-key-at-least-32-bytes/' .env.compose
+          sed -i 's/CHANGE_ME/ci-only-database-password/' .env.compose
+      - name: Build and start Compose services
+        run: docker compose up --build -d
+      - name: Verify replenishment smoke
+        run: python scripts/verify_compose.py
+      - name: Restart API and MCP
+        run: docker compose restart api mcp
+      - name: Verify health after restart
+        run: python scripts/verify_compose.py --recovery-only
+      - name: Show safe Compose status on failure
+        if: failure()
+        run: docker compose ps
+      - name: Remove Compose services and volumes
+        if: always()
+        run: docker compose down -v --remove-orphans

--- a/scripts/verify_repository_safety.py
+++ b/scripts/verify_repository_safety.py
@@ -1,0 +1,120 @@
+"""Fail closed on tracked local secrets, placeholders and mutable Actions."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+_ALLOWED_ENV_NAMES = {".env.example", ".env.compose.example"}
+_FORBIDDEN_SUFFIXES = {".pem", ".key"}
+_PLACEHOLDER = re.compile(r"T[B]D|T[O]DO|稍后填[写]|待[定]|暂[定]")
+_CREDENTIALS = (
+    re.compile(r"Bearer [A-Za-z0-9._-]{16,}"),
+    re.compile(r"postgresql[^\s]*://[^\s:]+:[^\s@]+@"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{16,}"),
+)
+_USES = re.compile(r"^\s*(?:-\s+)?uses:\s*([^\s#]+)", re.MULTILINE)
+_PINNED_ACTION = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+_WRITE_PERMISSION = re.compile(
+    r"^\s*(?:permissions:\s*write-all|[A-Za-z_-]+:\s*write)\s*$",
+    re.MULTILINE,
+)
+_ATTACK_PATH = "src/opercerta/evaluation/executor.py"
+_ALLOWED_ATTACK_LINES = {
+    'return {"Authorization": f"Bearer x{token[1:]}"}',
+    'return {"Authorization": "Bearer malformed-wrong-issuer-token"}',
+}
+
+
+def tracked_paths(root: Path) -> tuple[Path, ...]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return tuple(Path(item) for item in result.stdout.split("\0") if item)
+
+
+def _is_forbidden_path(path: Path) -> bool:
+    name = path.name
+    return (
+        name.startswith(".env") and name not in _ALLOWED_ENV_NAMES
+    ) or path.suffix.lower() in _FORBIDDEN_SUFFIXES
+
+
+def _is_content_scope(relative: str) -> bool:
+    return (
+        relative in {"README.md", "IMPLEMENTATION_HANDOFF.md", "DOCUMENT_INDEX.md"}
+        or relative == "docs/development-log/current-state.md"
+        or relative.startswith("docs/release-evidence/")
+        or relative.startswith("src/")
+        or relative.startswith(".github/workflows/")
+    )
+
+
+def scan_repository(root: Path) -> tuple[str, ...]:
+    findings: list[str] = []
+    paths = tracked_paths(root)
+    relative_names = {path.as_posix() for path in paths}
+    attack_counts: Counter[str] = Counter()
+
+    for path in paths:
+        relative = path.as_posix()
+        if _is_forbidden_path(path):
+            findings.append(f"forbidden tracked file: {relative}")
+        if not _is_content_scope(relative):
+            continue
+        try:
+            text = (root / path).read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            findings.append(f"non-UTF-8 scoped file: {relative}")
+            continue
+
+        if _PLACEHOLDER.search(text):
+            findings.append(f"placeholder content: {relative}")
+
+        for line in text.splitlines():
+            stripped = line.strip()
+            if relative == _ATTACK_PATH and stripped in _ALLOWED_ATTACK_LINES:
+                attack_counts[stripped] += 1
+                continue
+            if any(pattern.search(line) for pattern in _CREDENTIALS):
+                findings.append(f"credential-like content: {relative}")
+
+        if relative.startswith(".github/workflows/"):
+            for action in _USES.findall(text):
+                if action.startswith("./"):
+                    continue
+                if not _PINNED_ACTION.fullmatch(action):
+                    findings.append(f"unpinned action: {relative}: {action}")
+            if _WRITE_PERMISSION.search(text):
+                findings.append(f"write permission: {relative}")
+
+    if _ATTACK_PATH in relative_names:
+        for allowed_line in sorted(_ALLOWED_ATTACK_LINES):
+            if attack_counts[allowed_line] != 1:
+                findings.append(
+                    "attack allowlist count: "
+                    f"{_ATTACK_PATH}: expected 1, observed {attack_counts[allowed_line]}"
+                )
+
+    return tuple(findings)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    findings = scan_repository(root)
+    if findings:
+        for finding in findings:
+            print(finding)
+        return 1
+    print("repository safety checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/runtime/test_ci_assets.py
+++ b/tests/unit/runtime/test_ci_assets.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+ACTION_PINS = {
+    "actions/checkout": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+    "actions/setup-python": "ece7cb06caefa5fff74198d8649806c4678c61a1",
+    "actions/setup-node": "820762786026740c76f36085b0efc47a31fe5020",
+    "astral-sh/setup-uv": "11f9893b081a58869d3b5fccaea48c9e9e46f990",
+}
+
+
+def workflow_text() -> str:
+    assert WORKFLOW.is_file(), "GitHub Actions workflow is missing"
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_ci_has_read_only_triggers_concurrency_and_pinned_actions() -> None:
+    text = workflow_text()
+
+    assert "pull_request:" in text
+    assert "workflow_dispatch:" in text
+    assert "branches: [main]" in text
+    assert "contents: read" in text
+    assert "cancel-in-progress: true" in text
+    assert "write-all" not in text
+    for owner_action, sha in ACTION_PINS.items():
+        assert f"{owner_action}@{sha}" in text
+
+
+def test_ci_fast_jobs_use_frozen_python_postgres_and_frontend_gates() -> None:
+    text = workflow_text()
+
+    for job_name in (
+        "repository-safety",
+        "python-quality",
+        "backend-tests",
+        "frontend",
+    ):
+        assert f"name: {job_name}" in text
+    assert 'python-version: "3.12"' in text
+    assert 'version: "0.11.28"' in text
+    assert "uv sync --frozen --all-groups" in text
+    assert "python scripts/verify_repository_safety.py" in text
+    assert "uv run ruff check ." in text
+    assert "uv run ruff format --check ." in text
+    assert "uv run mypy src" in text
+    assert "image: postgres:18" in text
+    assert (
+        "OPERCERTA_DATABASE_URL: postgresql+psycopg://opercerta_ci@127.0.0.1:5432/opercerta_ci"
+    ) in text
+    assert "PGPASSWORD: opercerta_ci_only" in text
+    assert "uv run pytest -q" in text
+    assert 'node-version: "24"' in text
+    assert "npm ci" in text
+    assert "npm run test:run" in text
+    assert "npm run build" in text

--- a/tests/unit/runtime/test_ci_assets.py
+++ b/tests/unit/runtime/test_ci_assets.py
@@ -56,3 +56,20 @@ def test_ci_fast_jobs_use_frozen_python_postgres_and_frontend_gates() -> None:
     assert "npm ci" in text
     assert "npm run test:run" in text
     assert "npm run build" in text
+
+
+def test_ci_compose_smoke_is_main_or_manual_only_and_always_cleans_up() -> None:
+    text = workflow_text()
+
+    assert "name: compose-smoke" in text
+    assert "needs: [repository-safety, python-quality, backend-tests, frontend]" in text
+    assert "github.event_name == 'workflow_dispatch'" in text
+    assert "github.ref == 'refs/heads/main'" in text
+    assert "docker compose up --build -d" in text
+    assert "python scripts/verify_compose.py" in text
+    assert "docker compose restart api mcp" in text
+    assert "python scripts/verify_compose.py --recovery-only" in text
+    assert "if: failure()" in text
+    assert "docker compose ps" in text
+    assert "if: always()" in text
+    assert "docker compose down -v --remove-orphans" in text

--- a/tests/unit/scripts/test_verify_repository_safety.py
+++ b/tests/unit/scripts/test_verify_repository_safety.py
@@ -1,0 +1,94 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def load_safety_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "verify_repository_safety",
+        ROOT / "scripts" / "verify_repository_safety.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+scan_repository = load_safety_module().scan_repository
+
+PINNED_CHECKOUT = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+ATTACK_PATH = "src/opercerta/evaluation/executor.py"
+ATTACK_LINES = """\
+def headers(token: str) -> dict[str, str]:
+    if token == "tampered":
+        return {"Authorization": f"Bearer x{token[1:]}"}
+    return {"Authorization": "Bearer malformed-wrong-issuer-token"}
+"""
+
+
+def tracked_repo(tmp_path: Path, files: dict[str, str]) -> Path:
+    subprocess.run(["git", "init", "--quiet", str(tmp_path)], check=True)
+    for relative_path, content in files.items():
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True)
+    return tmp_path
+
+
+def clean_files() -> dict[str, str]:
+    return {
+        "README.md": (
+            "# OperCerta\nMissing Bearer token is rejected.\nOperCerta release gate: CLOSED\n"
+        ),
+        ATTACK_PATH: ATTACK_LINES,
+        ".github/workflows/ci.yml": (
+            "permissions:\n  contents: read\n"
+            f"steps:\n  - uses: actions/checkout@{PINNED_CHECKOUT}\n"
+        ),
+    }
+
+
+def test_clean_repository_and_exact_attack_allowlist_pass(tmp_path: Path) -> None:
+    root = tracked_repo(tmp_path, clean_files())
+
+    assert scan_repository(root) == ()
+
+
+def test_forbidden_local_environment_file_fails(tmp_path: Path) -> None:
+    files = clean_files() | {".env.local": "SECRET=value\n"}
+    root = tracked_repo(tmp_path, files)
+
+    findings = scan_repository(root)
+
+    assert any("forbidden tracked file: .env.local" in item for item in findings)
+
+
+def test_unknown_credential_and_duplicate_attack_sample_fail(tmp_path: Path) -> None:
+    files = clean_files()
+    files["README.md"] += "Authorization example: Bearer actual-looking-token\n"
+    files[ATTACK_PATH] += 'return {"Authorization": "Bearer malformed-wrong-issuer-token"}\n'
+    root = tracked_repo(tmp_path, files)
+
+    findings = scan_repository(root)
+
+    assert any("credential-like content: README.md" in item for item in findings)
+    assert any("attack allowlist count" in item for item in findings)
+
+
+def test_unpinned_action_and_write_permission_fail(tmp_path: Path) -> None:
+    files = clean_files()
+    files[".github/workflows/ci.yml"] = """\
+permissions: write-all
+steps:
+  - uses: actions/checkout@v7
+"""
+    root = tracked_repo(tmp_path, files)
+
+    findings = scan_repository(root)
+
+    assert any("unpinned action" in item for item in findings)
+    assert any("write permission" in item for item in findings)


### PR DESCRIPTION
Adds pinned, read-only Python, PostgreSQL, frontend, repository-safety and Compose CI gates. Release gate remains CLOSED.