### PR TITLE
docs: record github actions ci evidence

### DIFF
--- a/DOCUMENT_INDEX.md
+++ b/DOCUMENT_INDEX.md
@@ -2,7 +2,9 @@
 
 新增已确认规格：`docs/superpowers/specs/2026-07-18-github-actions-ci-security-gate-design.md`（Private GitHub 仓库、分层 Actions、PostgreSQL 18、前后端门禁、Compose smoke、供应链固定与主分支保护；实施计划已创建）。
 
-新增待执行计划：`docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md`（仓库安全扫描器、四个快速 job、main Compose smoke、Private remote、真实 Actions、主分支保护与证据交接六项任务）。
+新增已执行计划：`docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md`（仓库安全扫描器、四个快速 job、main Compose smoke、Private remote、真实 Actions、主分支保护能力核验与证据交接六项任务）。
+
+新增验证证据：`docs/release-evidence/github-actions-ci.md`（Private remote、PR/main 真实 Actions、339 条后端回归、前端门禁、Compose 重启恢复和分支保护 HTTP 403 能力限制；发布门禁仍关闭）。
 
 新增已实施规格：`docs/superpowers/specs/2026-07-18-observability-security-regression-design.md`（服务端请求关联、安全结构化日志、低基数 Prometheus 指标与安全回归；本地门禁已通过）。
 
@@ -26,14 +28,14 @@
 
 新增证据：`docs/release-evidence/replenishment-contract-evaluation.md`（固定 30 条本地合成契约评测；30 passed、0 failed；不代表公开发布）。
 
-最后核验：2026-07-18，库存补货 Task 1–9、演示 JWT/RBAC、固定契约评测、单页控制台及可观测性安全基础已完成本地门禁，并完成 WSL2 Ubuntu Compose 健康、业务 smoke 与重启恢复验证；发布门禁仍关闭。
+最后核验：2026-07-18，Private `KXHXK/opercerta` 已建立，PR run `29642286517` 的四个快速门禁通过，main run `29642363033` 的五个 job（含 Compose 业务 smoke 与重启恢复）通过；Private 分支保护因账户能力返回 HTTP 403，未启用且采用人工 PR 规则；发布门禁仍关闭。
 
 本文件是 OperCerta 重要文档的中文目录，不复制正文。自动压缩或新会话开始时先阅读本文件，再按“优先级”读取当前状态、过程日志、相关决策、交接和实施计划。
 
 | 路径 | 用途 | 状态 | 最后核验 commit | 优先级 |
 | --- | --- | --- | --- | --- |
-| `README.md` | 项目概览与使用边界 | 已同步至可观测性与安全回归本地门禁完成 | 本次提交 | 2 |
-| `IMPLEMENTATION_HANDOFF.md` | 会话交接与下一动作 | 已同步至可观测性证据与剩余发布边界 | 本次提交 | 3 |
+| `README.md` | 项目概览与使用边界 | 已同步 Private GitHub Actions 远程门禁与剩余发布边界 | 本次提交 | 2 |
+| `IMPLEMENTATION_HANDOFF.md` | 会话交接与下一动作 | 已同步远程 CI 证据、保护能力限制与下一边界 | 本次提交 | 3 |
 | `docs/specs/2026-07-14-agent-project-naming-design.md` | 命名设计 | 已冻结基线 | `c7fa618` | 4 |
 | `docs/specs/AI_Agent四项目总体设计规格.md` | 总体设计 | 已冻结基线 | `48d299c` | 5 |
 | `docs/specs/2026-07-14-agent-portfolio-design.md` | 组合设计 | 已冻结基线 | `48d299c` | 5 |
@@ -47,7 +49,7 @@
 | `docs/superpowers/specs/2026-07-16-docker-linux-runtime-design.md` | Docker/Linux、健康检查与 Ubuntu VM 运行时边界 | 已确认；实施计划已创建 | 本次提交 | 1 |
 | `docs/superpowers/specs/2026-07-17-wsl2-runtime-amendment-design.md` | WSL2 Ubuntu 26.04 环境修订、Docker 包来源与 registry mirror 例外 | 已确认；基础拉取已验证 | 本次提交 | 1 |
 | `docs/superpowers/specs/2026-07-18-observability-security-regression-design.md` | 请求关联、安全日志、低基数指标与安全回归设计 | 已实施并完成本地门禁 | `29b2c97` | 1 |
-| `docs/superpowers/specs/2026-07-18-github-actions-ci-security-gate-design.md` | Private GitHub Actions 分层 CI 安全门禁设计 | 已确认；待实施计划 | 本次提交 | 1 |
+| `docs/superpowers/specs/2026-07-18-github-actions-ci-security-gate-design.md` | Private GitHub Actions 分层 CI 安全门禁设计 | 已实施并完成远程门禁 | 本次提交 | 1 |
 | `docs/superpowers/plans/2026-07-14-opercerta-reliability-kernel.md` | 可靠性内核 TDD 总计划 | Task 1–6 已执行 | 本次提交 | 1 |
 | `docs/superpowers/plans/2026-07-16-langgraph-restart-recovery.md` | Task 5 四点重启恢复可执行 TDD 计划 | 已执行；证据已归档 | 本次提交 | 1 |
 | `docs/superpowers/plans/2026-07-16-work-order-idempotency.md` | Task 4 幂等工单可执行 TDD 计划 | 已执行；证据已归档 | 本次提交 | 1 |
@@ -56,14 +58,14 @@
 | `docs/superpowers/plans/2026-07-15-windows-native-postgres-environment.md` | PostgreSQL 环境计划 | 本机安装、连接与文档同步已完成 | `84a7b08` | 2 |
 | `docs/superpowers/plans/2026-07-15-development-log-bootstrap.md` | 日志初始化计划 | 执行记录见开发日志 | `6c97d5d` | 1 |
 | `docs/superpowers/plans/2026-07-18-observability-security-regression.md` | 可观测性与安全回归七项原子 TDD 计划 | 已执行；证据已归档 | `db69f71` | 1 |
-| `docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md` | Private GitHub Actions CI 安全门禁实施计划 | 已创建；待执行 | 本次提交 | 1 |
+| `docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md` | Private GitHub Actions CI 安全门禁实施计划 | 已执行；远程证据已归档 | 本次提交 | 1 |
 | `docs/development-log/README.md` | 日志机制说明 | 已初始化 | `f70411f` | 1 |
-| `docs/development-log/current-state.md` | 当前已验证状态 | 已同步可观测性安全基础与剩余发布边界 | 本次提交 | 1 |
+| `docs/development-log/current-state.md` | 当前已验证状态 | 已同步 Private remote、真实 Actions 与剩余发布边界 | 本次提交 | 1 |
 | `docs/development-log/interview-casebook.md` | 实施问题、诊断、修复与面试复盘案例 | 已初始化；只记录真实证据和限制 | 本次提交 | 1 |
 | `docs/development-log/learning-method.md` | 学习掌握、单变量实验与面试训练方法 | 已初始化；后续随实施持续补充 | 本次提交 | 1 |
 | `docs/development-log/daily/2026-07-15.md` | 当日过程记录 | 已初始化 | `f70411f` | 2 |
 | `docs/development-log/daily/2026-07-16.md` | 当日过程记录 | 已记录库存补货 Task 1–9 实施、调试与验证 | 本次提交 | 2 |
-| `docs/development-log/daily/2026-07-18.md` | 当日过程记录 | 已记录前端与可观测性 TDD、门禁和限制 | 本次提交 | 2 |
+| `docs/development-log/daily/2026-07-18.md` | 当日过程记录 | 已记录前端、可观测性与 GitHub Actions 实施证据 | 本次提交 | 2 |
 | `docs/development-log/decisions/2026-07-15-windows-native-postgres.md` | 环境架构决策 | 已初始化 | `f70411f` | 2 |
 | `docs/development-log/decisions/2026-07-16-risk-based-review-and-progress-control.md` | 风险分级复核、进度口径与纵向闭环保护 | 已采用 | 本次提交 | 1 |
 | `docs/release-evidence/native-postgres-environment.md` | 本机数据库环境核验证据 | 已记录；不代表发布通过 | `fc974f5` | 2 |
@@ -76,6 +78,7 @@
 | `docs/release-evidence/docker-linux-runtime.md` | WSL2 Ubuntu Compose 健康、业务 smoke 与重启恢复证据 | 单节点本地验证通过；发布门禁仍关闭 | 本次提交 | 1 |
 | `docs/release-evidence/single-page-console.md` | 本地单页运营控制台测试与构建证据 | 本地前端验证通过；不代表公开发布 | `f88ddc5` | 1 |
 | `docs/release-evidence/observability-security-regression.md` | request_id、安全日志、低基数指标与安全回归证据 | 本地门禁通过；发布门禁仍关闭 | 本次提交 | 1 |
+| `docs/release-evidence/github-actions-ci.md` | Private remote、PR/main 分层 CI、Compose 重启恢复与保护能力证据 | 远程门禁通过；分支保护受账户能力限制；发布门禁仍关闭 | 本次提交 | 1 |
 
 ## 计划创建
 

--- a/IMPLEMENTATION_HANDOFF.md
+++ b/IMPLEMENTATION_HANDOFF.md
@@ -2,6 +2,7 @@
 
 ## 当前检查点
 
+- 2026-07-18 已建立 Private `KXHXK/opercerta` 与分层 GitHub Actions。PR `#1` run `29642286517` 的四个快速 job 通过；main run `29642363033` 的五个 job 全部通过，远程日志记录后端 `339 passed`、前端 9 个测试文件/15 条测试，以及 Compose 业务 smoke、API/MCP 重启恢复和无条件清理。证据见 `docs/release-evidence/github-actions-ci.md`。Private 分支保护因当前账户能力返回 HTTP 403，未启用；必须继续执行人工 PR 全绿后合并规则。发布门禁仍为 `CLOSED`。
 - 2026-07-18 已完成可观测性与安全回归基础：FastAPI `0.139.2`、服务端 request_id、异常后上下文清理、安全 JSON 日志、应用级低基数 Prometheus 指标、SSE 实际回放计数和默认关闭的 `/metrics`。完整后端门禁为 `332 passed in 74.58s`，Ruff、100 文件 format check、mypy 50 个源文件通过；证据见 `docs/release-evidence/observability-security-regression.md`。发布门禁仍为 `CLOSED`。
 
 - 2026-07-18 已完成本地单页运营控制台：React/Vite、内存 JWT、创建/读取/审批编排与 fetch SSE 审计快照回放。前端门禁为 9 个测试文件、15 个测试通过，构建通过；证据见 `docs/release-evidence/single-page-console.md`。这不是生产身份、完整浏览器端到端或公开发布验证。
@@ -15,7 +16,7 @@
 - Task 5 最终完整测试为 `116 passed`，重启矩阵十个独立 Pytest 进程实测 `10/10`；Ruff、format 和 mypy（19 个源文件）通过。这些是本地验证，不是生产指标。
 - checkpointer 首次连接失败 traceback 展开了当时的本地测试角色密码；代码、Git 和文档未保存该值，封装已改为无密码 DSN + 临时 `PGPASSWORD`。用户已同步轮换 PostgreSQL 角色密码与 `.env.local`，轮换后 focused checkpointer 回归新鲜 `4 passed`。
 - 后续采用风险分级复核：用户决定产品范围、成本、外部账号和发布；内部技术细节由 Codex 以 TDD、静态检查和证据负责。进度必须区分可靠性内核与完整发布范围。
-- 当前 Git 尚未配置远程仓库；本地 commit 不是远程备份。
+- 当前 Git 已配置 `origin` 为 Private `KXHXK/opercerta`，本地 `main` 跟踪 `origin/main`；禁止 force push、删除远程历史或未经全绿 PR 直接合并。
 - 发布门禁保持 `CLOSED`，不启动 ForenTrail 或其他项目。
 - 首个纵向业务闭环已确定为“库存不足 → 补货工单”；设计见 `docs/superpowers/specs/2026-07-16-inventory-replenishment-vertical-slice-design.md`，可执行计划见 `docs/superpowers/plans/2026-07-16-inventory-replenishment-vertical-slice.md`。
 - 库存补货 Task 1–7 已完成。Task 7 实现提交为 `9b830d2`：批准后重新读取库存与规则、比较审批绑定事实、幂等创建工单、写后读验证、拒绝终止、审批过期扫描、`OperationRunner` 和补货专用恢复协调器。
@@ -33,7 +34,7 @@
 ## 新对话必须先做
 
 1. 先阅读 `DOCUMENT_INDEX.md`、`docs/development-log/current-state.md` 和最近每日日志，再阅读相关设计、计划、交接和 Git 状态。
-2. 只实施 OperCerta；库存补货 Task 1–9、WSL2 Docker Compose、演示 JWT/RBAC、固定 30 条契约评测、单页控制台与可观测性安全基础已完成本地验收。下一步只进入生产身份/人工接管、CI/CD、Caddy/HTTPS 与公开部署等发布门禁剩余范围；公共 registry mirror 属于已记录的供应链例外，不启动其他项目。
+2. 只实施 OperCerta；库存补货 Task 1–9、WSL2 Docker Compose、演示 JWT/RBAC、固定 30 条契约评测、单页控制台、可观测性安全基础与 Private GitHub Actions 分层 CI 已有证据。下一步只进入生产身份/人工接管、Caddy/HTTPS、自动部署与公开发布等剩余门禁；公共 registry mirror 与 Private 分支保护账户限制均已留证，不启动其他项目。
 3. 运行集成测试前，以不回显方式从已忽略 `.env.local` 加载 `OPERCERTA_DATABASE_URL`；不得提交该文件或任何凭据。
 4. 每个效果数字都保留基线、测试数据、测量脚本和结果证据；指标未测出前使用目标值或空值，不写成已实现结果。
 5. 使用公开或合成数据，从零编写全部代码和文档，不导入任何原单位源码、数据、截图、模型、品牌或内部规则。
@@ -47,4 +48,4 @@
 
 ## 可复制到新对话的启动语
 
-> 工作目录为本 OperCerta 仓库根目录。请先读取 `DOCUMENT_INDEX.md`、`docs/development-log/current-state.md`、最近每日日志、`README.md`、`IMPLEMENTATION_HANDOFF.md`、`docs/specs/` 下的四份设计文件及当前相关规格、计划和证据；库存补货、WSL2 Compose、JWT/RBAC、固定评测、单页控制台与可观测性安全基础已完成本地门禁，发布门禁仍关闭。下一步只规划和实施 OperCerta 剩余发布范围，不复用旧公司材料，不虚构指标，不启动其他项目。
+> 工作目录为本 OperCerta 仓库根目录。请先读取 `DOCUMENT_INDEX.md`、`docs/development-log/current-state.md`、最近每日日志、`README.md`、`IMPLEMENTATION_HANDOFF.md`、`docs/specs/` 下的四份设计文件及当前相关规格、计划和证据；库存补货、WSL2 Compose、JWT/RBAC、固定评测、单页控制台、可观测性安全基础与 Private GitHub Actions 分层 CI 已有自动化证据，发布门禁仍关闭。下一步只规划和实施 OperCerta 剩余发布范围，不复用旧公司材料，不虚构指标，不启动其他项目。

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 OperCerta 是面向库存异常、设备告警和运营工单的智能运营处置 Agent 独立作品仓库。
 
-> 当前状态：库存不足到补货工单的 FastAPI 后端纵向闭环、演示 JWT/RBAC、30 条固定合成契约评测、本地单页运营控制台以及可观测性与安全回归基础均已完成本地验证；真实生产身份、CI/CD、HTTPS 和公开发布尚未完成，发布门禁保持关闭。
+> 当前状态：库存不足到补货工单的 FastAPI 后端纵向闭环、演示 JWT/RBAC、30 条固定合成契约评测、本地单页运营控制台、可观测性与安全回归，以及 Private GitHub Actions 分层 CI 均已有自动化证据；真实生产身份、HTTPS、自动部署和公开发布尚未完成，发布门禁保持关闭。
 
 ## 当前已验证范围
 
@@ -17,12 +17,13 @@ OperCerta 是面向库存异常、设备告警和运营工单的智能运营处�
 - 冻结依赖、`0002` 迁移升降级、审批竞态与 A/B 重启重复、真实 FastMCP + FastAPI 双服务进程和 PostgreSQL 终态事实。
 - WSL2 Ubuntu Compose 的非 root 应用镜像、独立 PostgreSQL named volume、API/MCP 健康检查、真实库存补货审批闭环、数据库断言和 API/MCP 重启恢复。
 - 服务端 UUIDv4 request_id、异常后上下文清理、安全 JSON 日志、应用级低基数 Prometheus 指标、SSE 实际回放计数，以及默认关闭的 `/metrics`。
+- Private GitHub remote、只读且固定 Action SHA 的四个 PR 快速门禁，以及 `main` 上实际通过的 Compose 业务 smoke、API/MCP 重启恢复和无条件清理。
 
-Task 7 新鲜证据见 [补货执行与重启恢复证据](docs/release-evidence/replenishment-execution-restart.md)，Task 1–9 总证据见 [库存补货后端纵向闭环证据](docs/release-evidence/inventory-replenishment-vertical-slice.md)，Docker/Linux 证据见 [WSL2 Ubuntu Compose 运行时证据](docs/release-evidence/docker-linux-runtime.md)，评测证据见 [固定契约评测](docs/release-evidence/replenishment-contract-evaluation.md)，本轮证据见 [可观测性与安全回归](docs/release-evidence/observability-security-regression.md)。这不是生产 IAM、HTTPS 或公开部署完成声明。
+Task 7 新鲜证据见 [补货执行与重启恢复证据](docs/release-evidence/replenishment-execution-restart.md)，Task 1–9 总证据见 [库存补货后端纵向闭环证据](docs/release-evidence/inventory-replenishment-vertical-slice.md)，Docker/Linux 证据见 [WSL2 Ubuntu Compose 运行时证据](docs/release-evidence/docker-linux-runtime.md)，评测证据见 [固定契约评测](docs/release-evidence/replenishment-contract-evaluation.md)，可观测性证据见 [可观测性与安全回归](docs/release-evidence/observability-security-regression.md)，远程门禁证据见 [GitHub Actions 分层 CI](docs/release-evidence/github-actions-ci.md)。这不是生产 IAM、HTTPS 或公开部署完成声明。
 
 ## 下一实施边界
 
-下一阶段仍只实施 OperCerta，进入发布门禁剩余范围；可在 CI 安全门禁与 Caddy/HTTPS 设计中择一继续，并在获得外部平台与发布权限后处理生产身份和公开部署，不启动其他项目。
+下一阶段仍只实施 OperCerta。Private GitHub Actions 分层 CI 已完成真实远程验证；下一边界为 Caddy/HTTPS 设计或生产身份/人工接管，需另行决策后实施，不启动其他项目。
 
 首个闭环已确定为“库存不足 → 补货工单”，采用独立 FastMCP 服务、四个真实 MCP 工具、Mock 结构化模型、LangGraph 和 FastAPI；[设计规格](docs/superpowers/specs/2026-07-16-inventory-replenishment-vertical-slice-design.md)与[可执行 TDD 计划](docs/superpowers/plans/2026-07-16-inventory-replenishment-vertical-slice.md)已落盘并执行至 Task 9。
 

--- a/docs/development-log/current-state.md
+++ b/docs/development-log/current-state.md
@@ -1,8 +1,8 @@
 # OperCerta 当前状态
 
-## 下一实施边界：Private GitHub Actions 分层 CI
+## 最新核验：Private GitHub Actions 分层 CI 已完成
 
-2026-07-18 已确认采用 Private GitHub 仓库与分层 Actions：PR/push 运行仓库安全、Python 静态门禁、PostgreSQL 18 完整后端测试和前端门禁；`main`/手动运行追加 Compose 业务 smoke 与重启恢复。设计见 `docs/superpowers/specs/2026-07-18-github-actions-ci-security-gate-design.md`，实施计划见 `docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md`。当前尚未创建远程仓库、workflow 或真实 GitHub run；发布门禁保持 `CLOSED`。
+2026-07-18 已建立 Private `KXHXK/opercerta` 和只读、固定 Action SHA 的分层 Actions。PR `#1` run `29642286517` 的四个快速 job 成功，`compose-smoke` 按设计跳过；main run `29642363033` 的五个 job 全部成功，远程实测后端 `339 passed in 29.46s`、前端 9 个测试文件/15 条测试、Ruff、104 文件格式检查、mypy 50 个源文件、Compose 业务 smoke、API/MCP 重启恢复与无条件清理。Private 分支保护 API 因当前账户能力返回 HTTP 403，未启用并采用人工 PR 全绿后合并规则。证据见 `docs/release-evidence/github-actions-ci.md`；发布门禁保持 `CLOSED`。
 
 ## 最新核验：可观测性与安全回归基础已完成
 
@@ -88,17 +88,17 @@
 
 ## 当前阻塞与风险
 
-- 设备场景、生产 IAM/SSO、人工接管、CI/CD、Caddy/HTTPS、集中指标采集/告警和公开部署尚未完成，发布门禁保持关闭。
+- 设备场景、生产 IAM/SSO、人工接管、自动部署、Caddy/HTTPS、集中指标采集/告警和公开部署尚未完成，发布门禁保持关闭。
 - Windows 原生真实服务需要显式 Selector loop；WSL2 Ubuntu Compose 已验证默认 Linux 容器进程、健康检查、MCP 服务名访问、独立 PostgreSQL volume 和 API/MCP 重启，但这不代表高可用或生产承诺。
 - Docker/Linux 运行时已修订为 WSL2 → Ubuntu 26.04 LTS，不使用 Docker Desktop 或 Hyper-V VM。Ubuntu 官方仓库的 Docker `29.1.3`、Compose `2.40.3`、Buildx `0.30.1` 已安装；Docker Hub 直连超时后，经用户授权配置了三个可达的第三方 registry mirror。OperCerta Compose 已通过构建、健康、真实业务数据库断言与重启恢复；完整证据见 `docs/release-evidence/docker-linux-runtime.md`，供应链例外见 `docs/superpowers/specs/2026-07-17-wsl2-runtime-amendment-design.md`。
 - 一次预期失败的 Pytest/Psycopg traceback 曾展开旧的本地测试数据库连接密码；代码、Git 和文档未保存该值，fixture 已改为无密码 URL + 临时 `PGPASSWORD`，角色密码也已轮换和复验。
 - 2026-07-16 checkpointer 首次 GREEN 的 Psycopg 连接失败 traceback 再次展开当时的本地测试角色密码。新封装已改为无密码 DSN、临时 `PGPASSWORD` 和 `%20` query 编码，代码/Git/文档未保存该值；用户随后同步轮换 PostgreSQL 角色与 `.env.local`，focused checkpointer 回归新鲜 `4 passed`。
-- 当前 Git 没有配置远程仓库；本地 commit 不是远程备份。
+- 当前 Git 已配置 Private `origin`，`main` 跟踪 `origin/main`。当前账户对 Private 仓库启用 branch protection 返回 HTTP 403，因此保护未启用；所有改动必须人工坚持 PR、四个快速 job 全绿后合并，并在合并后核验 `compose-smoke`。
 
 ## 下一步
 
-继续只实施 OperCerta。下一步按已确认计划实施本地安全扫描器和 Actions workflow；创建 Private 仓库前仍需确认实际 GitHub owner/身份。Caddy/HTTPS、生产 IAM、人工接管和公开部署不在本阶段。公共 registry mirror 的风险与后续每个实际镜像 digest 仍须留证。
+继续只实施 OperCerta。Private GitHub Actions 分层 CI 已完成真实远程验证；下一决策边界为 Caddy/HTTPS 设计或生产 IAM/人工接管，之后才处理自动部署和公开发布。公共 registry mirror 的风险与后续每个实际镜像 digest 仍须留证。
 
 ## 发布门禁
 
-`OperCerta release gate: CLOSED`。当前证据证明库存补货纵向切片、WSL2 Compose、演示身份、固定评测、单页控制台和可观测性安全基础在本地通过；完整产品面、生产身份、HTTPS、CI/CD 和公开部署仍待完成。
+`OperCerta release gate: CLOSED`。当前证据证明库存补货纵向切片、WSL2 Compose、演示身份、固定评测、单页控制台、可观测性安全基础与 Private GitHub Actions 分层 CI 通过；完整产品面、生产身份、HTTPS、自动部署和公开发布仍待完成。

--- a/docs/development-log/daily/2026-07-18.md
+++ b/docs/development-log/daily/2026-07-18.md
@@ -52,4 +52,20 @@
 - CI 安全扫描会精确 allowlist 固定评测执行器的两处攻击 token 样本，未知路径、模式或数量仍失败；不通过拆字规避扫描。
 - 本步骤只完成并确认设计；尚未创建 GitHub remote、workflow、CI run 或分支保护，也没有部署。
 - 已把确认设计拆为六项可执行任务：仓库安全扫描器、四个快速 Actions job、main Compose smoke、本地总门禁、Private remote 与真实 PR/main run、主分支保护和证据交接。计划见 `docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md`；本步骤仍未创建远程或修改运行代码。
+
+## GitHub Actions CI 安全门禁实施
+
+- 在隔离 worktree 的 `ci/github-actions-gate` 分支按 TDD 实施。Task 1 新增受测试保护的仓库安全扫描器；RED 首先证明模块缺失，GREEN 后锁定受禁环境文件、凭据模式、精确攻击样本 allowlist、Action 完整 SHA 和只读权限。
+- 扫描器首次真实运行把演示证据中的普通描述误识别为凭据，新增回归测试后把 Bearer 检测收紧为至少 16 个字符；没有删除攻击测试或拆字逃避扫描。
+- Task 2 新增四个快速 job：`repository-safety`、`python-quality`、PostgreSQL 18 `backend-tests`、`frontend`。workflow 解析、6 条契约测试、安全扫描、Ruff 和格式检查通过，提交 `61d7822`。
+- Task 3 先写缺少 `compose-smoke` 的 RED，再实现仅 `main` push/手动触发的构建、库存补货 smoke、API/MCP 重启、恢复验证、失败状态诊断和无条件卷清理。完整本地门禁为后端 `339 passed in 77.34s`、mypy 50 个源文件、前端 9 文件/15 条测试和生产构建，提交 `265d611`。
+- 用户确认 GitHub owner 为 `KXHXK` 并手工创建 Private `KXHXK/opercerta`。本地通过 Git Credential Manager 保存账号并正常推送 `main` 与功能分支，无 force push。
+- GitHub 插件只完成了用户身份核验，但安装列表为空，无法读取新 Private 仓库；内置浏览器两次加载比较页超时。为避免依赖浏览器自动化，下载 GitHub 官方便携 CLI `2.96.0`，校验 SHA-256 后放入用户本地工具目录，不修改系统 PATH。
+- GitHub CLI 设备登录接口在当前网络超时；复用 Git Credential Manager 凭据做持久登录时，又因缺少 CLI 强制要求的 `read:org` scope 被拒绝。最终采用最小权限方式：凭据只进入单个子进程的 `GH_TOKEN` 环境变量，命令结束立即清除；未在日志、文档或项目文件中输出 token。
+- PR `#1` 创建并合并。PR run `29642286517` 四个快速 job 成功，`compose-smoke` 按设计跳过；main run `29642363033` 五个 job 全部成功。
+- main 远程日志实测：Ruff 通过、104 个文件格式正确、mypy 50 个源文件、后端 `339 passed in 29.46s`、前端 9 文件/15 条测试、0 个 npm 审计漏洞、Compose 业务 smoke、API/MCP 重启恢复和无条件资源清理均成功。
+- setup-uv 并发保存相同 cache 出现非致命 reservation annotation，但相关 job 与 run 结论均为 `success`；没有加入 `continue-on-error`。
+- 读取 Private `main` branch protection 返回 HTTP 403，GitHub 要求升级账户计划或把仓库改为 Public。按已确认边界不公开、不购买、不重试写入，明确记录保护未启用，并采用人工 PR 四门禁全绿后合并、main Compose 再验证的替代规则。
+- 完整远程证据见 `docs/release-evidence/github-actions-ci.md`。这完成了分层 CI，不代表生产 IAM、HTTPS、自动部署或公开上线；发布门禁继续为 `CLOSED`。
+- 证据文档完成后执行最终本地总门禁：安全扫描通过；后端 `339 passed in 75.85s`；Ruff 通过；104 个文件格式正确；mypy 检查 50 个源文件无问题；前端 9 个测试文件/15 条测试通过，Vite 生产构建用时 2.40s。
 - 官方 tag 对应 SHA 已通过 `git ls-remote` 核验并写入计划；workflow 将固定完整 SHA，不使用可变 tag。

--- a/docs/release-evidence/github-actions-ci.md
+++ b/docs/release-evidence/github-actions-ci.md
@@ -1,0 +1,51 @@
+# GitHub Actions 分层 CI：远程验证证据
+
+## 范围与仓库可见性
+
+- 核验时间：2026-07-18（Asia/Shanghai）。
+- 仓库：`KXHXK/opercerta`，GitHub API 返回 `visibility: PRIVATE`。
+- 默认分支：`main`；远程地址：`https://github.com/KXHXK/opercerta`。
+- 本证据不记录认证方式、OAuth scope、token、密码或本地凭据内容。
+
+## PR 快速门禁
+
+- PR：`#1`，地址：`https://github.com/KXHXK/opercerta/pull/1`。
+- run ID：`29642286517`；commit：`265d611225341431cb94bf2a6b954155a40f0606`；event：`pull_request`；结论：`success`。
+- run 地址：`https://github.com/KXHXK/opercerta/actions/runs/29642286517`。
+- `repository-safety`、`python-quality`、`backend-tests`、`frontend` 均为 `success`。
+- `compose-smoke` 为 `skipped`，符合只在 `main` push 或手动触发时运行的设计。
+
+## main 完整门禁
+
+- PR 合并 commit：`be00ee78e12b841bfd8d17f30f2ad4f9fdc15bf6`。
+- run ID：`29642363033`；event：`push`；结论：`success`。
+- run 地址：`https://github.com/KXHXK/opercerta/actions/runs/29642363033`。
+- 五个 job 的远程结论均为 `success`：`repository-safety`、`python-quality`、`backend-tests`、`frontend`、`compose-smoke`。
+- 远程日志实际结果：仓库安全扫描通过；Ruff 通过；104 个文件格式正确；mypy 检查 50 个源文件无问题；后端 `339 passed in 29.46s`；前端 9 个测试文件、15 条测试通过；`npm ci` 审计为 0 个漏洞；Vite 生产构建用时 205ms。
+- `compose-smoke` 远程步骤依次成功：构建并启动服务、执行库存补货 smoke、重启 API/MCP、执行恢复健康验证、无条件删除服务、网络和 PostgreSQL volume。失败诊断步骤因 run 成功而按设计跳过。
+- setup-uv 在并发 job 保存相同 cache 时产生一次非致命 reservation annotation；job 和整个 run 的结论仍为 `success`，未通过 `continue-on-error` 放宽门禁。
+
+## 供应链与凭据边界
+
+- workflow 顶层权限为 `contents: read`，所有 job 失败关闭，未配置 `continue-on-error`。
+- Python 使用 `uv sync --frozen --all-groups` 和 `uv 0.11.28`；前端使用 `npm ci`；PostgreSQL service 使用 `postgres:18`。
+- 四个远程 Action 固定到完整 commit SHA：
+  - `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`
+  - `actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1`
+  - `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020`
+  - `astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990`
+- PostgreSQL、JWT 与 Compose 只使用 GitHub runner 内的合成值；CI 不读取 `.env.local`、`.env.compose` 或真实本地凭据。
+- 仓库安全扫描器只允许固定评测执行器中两行、各出现一次的攻击样本；未知凭据模式、数量变化、可变 Action、写权限、受禁跟踪文件和占位文本均失败关闭。
+
+## 主分支保护
+
+- 对 `main` 读取 branch protection 时，GitHub API 返回 HTTP 403：当前账户计划需要升级 GitHub Pro 或将仓库改为 Public 才能启用该 Private 仓库功能。
+- 未把仓库改为 Public，未购买套餐，未写成已经启用保护，也未尝试削弱检查。
+- 当前人工替代规则：所有改动通过 PR；合并前必须确认 `repository-safety`、`python-quality`、`backend-tests`、`frontend` 全绿；禁止 force push 和删除远程历史。`compose-smoke` 在合并后的 `main` run 验证。
+
+## 已知限制
+
+- 证据文档完成后的最终本地复验为：仓库安全扫描通过；后端 `339 passed in 75.85s`；Ruff 通过；104 个文件格式正确；mypy 检查 50 个源文件无问题；前端 9 个测试文件、15 条测试通过；Vite 生产构建用时 2.40s。该组数字与上文远程日志数字分开记录。
+- 未实现 CodeQL/GHAS、漏洞扫描、自动部署、Caddy/HTTPS、生产 IAM、公开仓库或公开服务。
+- 当前证据证明 Private GitHub Actions 分层 CI 与单节点 Compose 重启恢复门禁通过，不代表生产高可用、SLA 或公开上线。
+- `OperCerta release gate: CLOSED`。

--- a/docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md
+++ b/docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md
@@ -37,7 +37,7 @@
 - Produces: `tracked_paths(root: Path) -> tuple[Path, ...]`, `scan_repository(root: Path) -> tuple[str, ...]`, `main() -> int`.
 - Exit contract: zero findings returns 0; any forbidden path, placeholder, credential pattern, unpinned Action, write permission or changed attack allowlist returns 1.
 
-- [ ] **Step 1: 写安全扫描 RED 测试**
+- [x] **Step 1: 写安全扫描 RED 测试**
 
 ```python
 # tests/unit/scripts/test_verify_repository_safety.py
@@ -121,7 +121,7 @@ steps:
     assert any("write permission" in item for item in findings)
 ```
 
-- [ ] **Step 2: 运行 RED**
+- [x] **Step 2: 运行 RED**
 
 Run:
 
@@ -131,7 +131,7 @@ uv run pytest tests/unit/scripts/test_verify_repository_safety.py -q
 
 Expected: collection exits 1 with `ModuleNotFoundError: No module named 'scripts.verify_repository_safety'`.
 
-- [ ] **Step 3: 实现最小扫描器**
+- [x] **Step 3: 实现最小扫描器**
 
 ```python
 # scripts/verify_repository_safety.py
@@ -260,7 +260,7 @@ if __name__ == "__main__":
 
 Create empty `scripts/__init__.py` and `tests/unit/scripts/__init__.py`.
 
-- [ ] **Step 4: 运行 GREEN、真实仓库扫描和静态检查**
+- [x] **Step 4: 运行 GREEN、真实仓库扫描和静态检查**
 
 Run:
 
@@ -287,7 +287,7 @@ uv run ruff format --check scripts tests/unit/scripts
 
 Expected: both exit 0.
 
-- [ ] **Step 5: 提交扫描器**
+- [x] **Step 5: 提交扫描器**
 
 ```powershell
 git add scripts/__init__.py scripts/verify_repository_safety.py tests/unit/scripts
@@ -306,7 +306,7 @@ git commit -m "feat: verify repository safety"
 - Consumes: Task 1 CLI, `uv.lock`, `web/package-lock.json`, PostgreSQL 18 and existing pytest fixtures.
 - Produces: stable job/check names `repository-safety`, `python-quality`, `backend-tests`, `frontend`.
 
-- [ ] **Step 1: 写快速 workflow 契约 RED 测试**
+- [x] **Step 1: 写快速 workflow 契约 RED 测试**
 
 ```python
 # tests/unit/runtime/test_ci_assets.py
@@ -368,7 +368,7 @@ def test_ci_fast_jobs_use_frozen_python_postgres_and_frontend_gates() -> None:
     assert "npm run build" in text
 ```
 
-- [ ] **Step 2: 运行 RED**
+- [x] **Step 2: 运行 RED**
 
 Run:
 
@@ -378,7 +378,7 @@ uv run pytest tests/unit/runtime/test_ci_assets.py -q
 
 Expected: both tests fail with `GitHub Actions workflow is missing`.
 
-- [ ] **Step 3: 实现四个快速 job**
+- [x] **Step 3: 实现四个快速 job**
 
 ```yaml
 # .github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
         run: npm run build
 ```
 
-- [ ] **Step 4: 运行 GREEN 与扫描器回归**
+- [x] **Step 4: 运行 GREEN 与扫描器回归**
 
 Run:
 
@@ -529,7 +529,7 @@ uv run ruff format --check scripts tests/unit
 
 Expected: both exit 0.
 
-- [ ] **Step 5: 提交快速门禁**
+- [x] **Step 5: 提交快速门禁**
 
 ```powershell
 git add .github/workflows/ci.yml tests/unit/runtime/test_ci_assets.py
@@ -548,7 +548,7 @@ git commit -m "ci: add fast github actions gates"
 - Consumes: Task 2 four fast jobs and `scripts/verify_compose.py`.
 - Produces: stable job/check name `compose-smoke`, safe failure diagnostics and unconditional cleanup.
 
-- [ ] **Step 1: 写 Compose workflow RED 测试**
+- [x] **Step 1: 写 Compose workflow RED 测试**
 
 Append:
 
@@ -571,7 +571,7 @@ def test_ci_compose_smoke_is_main_or_manual_only_and_always_cleans_up() -> None:
     assert "docker compose down -v --remove-orphans" in text
 ```
 
-- [ ] **Step 2: 运行 RED**
+- [x] **Step 2: 运行 RED**
 
 Run:
 
@@ -581,7 +581,7 @@ uv run pytest tests/unit/runtime/test_ci_assets.py::test_ci_compose_smoke_is_mai
 
 Expected: fail because `compose-smoke` is absent.
 
-- [ ] **Step 3: 在 workflow 末尾增加 Compose job**
+- [x] **Step 3: 在 workflow 末尾增加 Compose job**
 
 ```yaml
   compose-smoke:
@@ -621,7 +621,7 @@ Expected: fail because `compose-smoke` is absent.
         run: docker compose down -v --remove-orphans
 ```
 
-- [ ] **Step 4: 运行 GREEN、完整本地后端与前端门禁**
+- [x] **Step 4: 运行 GREEN、完整本地后端与前端门禁**
 
 Run:
 
@@ -653,7 +653,7 @@ npm run build
 
 Expected: all exit 0; record actual test file/test counts and build result.
 
-- [ ] **Step 5: 提交 Compose 门禁**
+- [x] **Step 5: 提交 Compose 门禁**
 
 ```powershell
 git add .github/workflows/ci.yml tests/unit/runtime/test_ci_assets.py
@@ -671,7 +671,7 @@ git commit -m "ci: verify compose on main"
 - Consumes: authenticated GitHub connector or `gh`, clean `ci/github-actions-gate` branch and Tasks 1–3 commits.
 - Produces: Private `opercerta` repository, configured `origin`, initial PR run and merged `main` run.
 
-- [ ] **Step 1: 核验 GitHub 身份并设置人工确认点**
+- [x] **Step 1: 核验 GitHub 身份并设置人工确认点**
 
 Run:
 
@@ -682,7 +682,7 @@ gh api user --jq .login
 
 Expected: authenticated account login is printed without token. Show that login to the user and obtain explicit confirmation that it is the intended owner before creating the repository. If `gh` is unavailable, use the installed GitHub connector; if neither is authenticated, stop and ask the user to complete GitHub authentication.
 
-- [ ] **Step 2: 核验本地分支、工作区与远程名称可用性**
+- [x] **Step 2: 核验本地分支、工作区与远程名称可用性**
 
 Run:
 
@@ -703,7 +703,7 @@ gh repo view "$owner/opercerta" --json nameWithOwner,visibility,url
 
 Expected for a new repository: exit 1/not found. If it exists, stop; do not overwrite or reuse it without user direction.
 
-- [ ] **Step 3: 创建 Private 仓库并验证可见性**
+- [x] **Step 3: 创建 Private 仓库并验证可见性**
 
 ```powershell
 $owner = gh api user --jq .login
@@ -713,7 +713,7 @@ gh repo view "$owner/opercerta" --json nameWithOwner,visibility,url
 
 Expected: JSON reports the confirmed owner, repository `opercerta`, and `visibility: PRIVATE`.
 
-- [ ] **Step 4: 配置 origin，先推 main 基线，再推 CI 分支并创建 PR**
+- [x] **Step 4: 配置 origin，先推 main 基线，再推 CI 分支并创建 PR**
 
 ```powershell
 $owner = gh api user --jq .login
@@ -725,7 +725,7 @@ gh pr create --base main --head (git branch --show-current) --title "ci: add git
 
 Expected: both branches push without force, and one open PR targets `main`.
 
-- [ ] **Step 5: 观察 PR 快速门禁，失败时按证据修复**
+- [x] **Step 5: 观察 PR 快速门禁，失败时按证据修复**
 
 ```powershell
 $commit = git rev-parse HEAD
@@ -742,7 +742,7 @@ gh run view $runId --json headSha,event,status,conclusion,jobs,url
 
 Expected: `repository-safety`、`python-quality`、`backend-tests`、`frontend` success；`compose-smoke` skipped on PR. If any job fails, inspect only that job with `gh run view $runId --log-failed`, identify the root cause, add or tighten a local regression test, commit the fix, push normally and repeat this step. Do not use `continue-on-error`, remove assertions or expose environment variables.
 
-- [ ] **Step 6: 合并 PR 并观察 main 的全部五个 job**
+- [x] **Step 6: 合并 PR 并观察 main 的全部五个 job**
 
 ```powershell
 gh pr merge --merge --delete-branch=false
@@ -773,7 +773,7 @@ Expected: main run has all five jobs success, including `compose-smoke`; commit 
 - Consumes: Task 4 successful main run and authenticated owner.
 - Produces: verified branch protection requiring the four fast checks, or an evidence-backed account limitation.
 
-- [ ] **Step 1: 读取当前 protection 状态**
+- [x] **Step 1: 读取当前 protection 状态**
 
 ```powershell
 $owner = gh api user --jq .login
@@ -782,7 +782,7 @@ gh api "repos/$owner/opercerta/branches/main/protection"
 
 Expected before configuration: 404/unprotected or existing settings that must be shown to the user before modification. Never overwrite unexpected existing protection silently.
 
-- [ ] **Step 2: 启用不要求外部 reviewer 的 protection**
+- [x] **Step 2: 启用不要求外部 reviewer 的 protection**
 
 Run in PowerShell with the confirmed owner:
 
@@ -816,7 +816,7 @@ $payload | gh api --method PUT "repos/$owner/opercerta/branches/main/protection"
 
 Expected: success JSON. If GitHub returns a plan/capability error, do not retry by weakening repository visibility or purchasing a plan; capture the status/code for Task 6 and use the documented manual rule.
 
-- [ ] **Step 3: 回读并验证保护事实**
+- [x] **Step 3: 回读并验证保护事实**
 
 ```powershell
 $owner = gh api user --jq .login
@@ -842,7 +842,7 @@ Expected if supported: four exact fast contexts; `enforce_admins: true`、`force
 - Consumes: actual PR/main run JSON, current Git commit, repository visibility and protection response.
 - Produces: Chinese evidence with observed facts only and a clean local `main` tracking `origin/main`.
 
-- [ ] **Step 1: 采集远程只读事实，不采集 token**
+- [x] **Step 1: 采集远程只读事实，不采集 token**
 
 Run:
 
@@ -857,7 +857,7 @@ git branch -vv
 
 Expected: Private repository, default branch `main`, successful current main run, clean worktree and local main tracking origin/main. Record only the actual returned run ID/SHA/event/conclusion/URL.
 
-- [ ] **Step 2: 写中文远程 CI 证据**
+- [x] **Step 2: 写中文远程 CI 证据**
 
 Create `docs/release-evidence/github-actions-ci.md` with exactly these sections and only observed values from Step 1 and Tasks 4–5:
 
@@ -883,7 +883,7 @@ Create `docs/release-evidence/github-actions-ci.md` with exactly these sections 
 明确未实现 CodeQL/GHAS、漏洞扫描、自动部署、Caddy/HTTPS、生产 IAM 或公开仓库，release gate 为 CLOSED。
 ```
 
-- [ ] **Step 3: 同步 README、索引、当前状态、交接和日志**
+- [x] **Step 3: 同步 README、索引、当前状态、交接和日志**
 
 Only state facts proven by remote output:
 
@@ -896,7 +896,7 @@ Only state facts proven by remote output:
 
 Mark completed plan checkboxes `- [x]` without deleting RED/GREEN commands or failure diagnostics.
 
-- [ ] **Step 4: 运行最终本地门禁与敏感扫描**
+- [x] **Step 4: 运行最终本地门禁与敏感扫描**
 
 Run from repository root:
 


### PR DESCRIPTION
Records observed Private GitHub Actions results and keeps the release gate CLOSED.