### PR TITLE
docs: complete github actions plan

### DIFF
--- a/docs/development-log/daily/2026-07-18.md
+++ b/docs/development-log/daily/2026-07-18.md
@@ -68,4 +68,5 @@
 - 读取 Private `main` branch protection 返回 HTTP 403，GitHub 要求升级账户计划或把仓库改为 Public。按已确认边界不公开、不购买、不重试写入，明确记录保护未启用，并采用人工 PR 四门禁全绿后合并、main Compose 再验证的替代规则。
 - 完整远程证据见 `docs/release-evidence/github-actions-ci.md`。这完成了分层 CI，不代表生产 IAM、HTTPS、自动部署或公开上线；发布门禁继续为 `CLOSED`。
 - 证据文档完成后执行最终本地总门禁：安全扫描通过；后端 `339 passed in 75.85s`；Ruff 通过；104 个文件格式正确；mypy 检查 50 个源文件无问题；前端 9 个测试文件/15 条测试通过，Vite 生产构建用时 2.40s。
+- 证据 PR `#2` 的四个快速 job 通过并合并；合并 commit `4b392ed4eeb6998d4f2bd666880453c3bd4a275b` 对应 main run `29642949588` 的五个 job 再次全部成功。实施计划最后一步只在该事后证据产生后标记完成。
 - 官方 tag 对应 SHA 已通过 `git ls-remote` 核验并写入计划；workflow 将固定完整 SHA，不使用可变 tag。

--- a/docs/release-evidence/github-actions-ci.md
+++ b/docs/release-evidence/github-actions-ci.md
@@ -24,6 +24,7 @@
 - 远程日志实际结果：仓库安全扫描通过；Ruff 通过；104 个文件格式正确；mypy 检查 50 个源文件无问题；后端 `339 passed in 29.46s`；前端 9 个测试文件、15 条测试通过；`npm ci` 审计为 0 个漏洞；Vite 生产构建用时 205ms。
 - `compose-smoke` 远程步骤依次成功：构建并启动服务、执行库存补货 smoke、重启 API/MCP、执行恢复健康验证、无条件删除服务、网络和 PostgreSQL volume。失败诊断步骤因 run 成功而按设计跳过。
 - setup-uv 在并发 job 保存相同 cache 时产生一次非致命 reservation annotation；job 和整个 run 的结论仍为 `success`，未通过 `continue-on-error` 放宽门禁。
+- 证据 PR `#2` 合并后，commit `4b392ed4eeb6998d4f2bd666880453c3bd4a275b` 的 main run `29642949588` 再次验证五个 job 全部 `success`，其中 `compose-smoke` 完成业务 smoke、API/MCP 重启、恢复验证和清理。
 
 ## 供应链与凭据边界
 

--- a/docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md
+++ b/docs/superpowers/plans/2026-07-18-github-actions-ci-security-gate.md
@@ -926,7 +926,7 @@ git status --short
 
 Expected: diff check exits 0; only the planned documentation files are modified.
 
-- [ ] **Step 5: 提交证据并推送受保护 main**
+- [x] **Step 5: 提交证据并推送受保护 main**
 
 Because Task 5 may now protect `main`, create a documentation branch if direct push is rejected:
 


### PR DESCRIPTION
Records the post-evidence main run and marks the verified CI plan complete. Release gate remains CLOSED.