### PR TITLE
docs: record OperCerta showcase release evidence

### DIFF
--- a/DOCUMENT_INDEX.md
+++ b/DOCUMENT_INDEX.md
@@ -1,16 +1,16 @@
 # OperCerta 文档总索引
 
-本索引分别登记 OperCerta 根工作树和 6 个 .worktrees/ 工作树中的项目 Markdown 文档，共 544 份。每个工作树使用独立表格和独立序号；路径均相对于仓库根目录；日期表示文档首次建立日期。Git 元数据、依赖目录、虚拟环境和工具缓存不属于项目文档登记范围。
+本索引分别登记 OperCerta 根工作树和 6 个 .worktrees/ 工作树中的项目 Markdown 文档，共 546 份。每个工作树使用独立表格和独立序号；路径均相对于仓库根目录；日期表示文档首次建立日期。Git 元数据、依赖目录、虚拟环境和工具缓存不属于项目文档登记范围。
 
-## 根工作树（89 份）
+## 根工作树（90 份）
 
 | 序号 | 文件名 | 路径 | 用途（详细） | 状态 | 日期 |
 | ---: | --- | --- | --- | --- | --- |
 | 1 | `README.md` | `README.md` | 项目总入口，说明三业务场景、核心技术栈、运行方式、演示边界、学习入口和发布门禁，供开发者、审阅者与面试官快速了解 OperCerta。 | 已同步三业务、本地发布候选、学习入口与剩余门禁 | 2026-07-14 |
 | 2 | `IMPLEMENTATION_HANDOFF.md` | `IMPLEMENTATION_HANDOFF.md` | 跨对话和上下文压缩后的实施交接文件，记录当前分支、已验证事实、未完成事项、下一步动作及禁止越过的发布边界。 | 已同步真实模型验证与公网发布下一边界 | 2026-07-14 |
-| 3 | `DOCUMENT_INDEX.md` | `DOCUMENT_INDEX.md` | OperCerta 全部项目文档的唯一总登记表，用于按文件名、路径、用途、状态和日期统一检索、复查与交接。 | 已按根工作树与 6 个 worktree 独立分表登记；总计 544 份项目 Markdown，排除依赖、虚拟环境和工具缓存 | 2026-07-15 |
+| 3 | `DOCUMENT_INDEX.md` | `DOCUMENT_INDEX.md` | OperCerta 全部项目文档的唯一总登记表，用于按文件名、路径、用途、状态和日期统一检索、复查与交接。 | 已按根工作树与 6 个 worktree 独立分表登记；总计 546 份项目 Markdown，排除依赖、虚拟环境和工具缓存 | 2026-07-15 |
 | 4 | `2026-07-14-agent-project-naming-design.md` | `docs/specs/2026-07-14-agent-project-naming-design.md` | 定义 OperCerta、ForenTrail、SiteVerum、Federune 四个项目的命名原则、语义边界与品牌一致性，防止项目职责和名称漂移。 | 已冻结为命名基线 | 2026-07-14 |
-| 5 | `ai-agent-portfolio-overall-design.md` | `docs/specs/ai-agent-portfolio-overall-design.md` | 规定四个 AI Agent 项目的整体定位、差异化业务范围、技术能力组合、实施顺序和共同约束，是项目组合的最高层设计依据。 | 已冻结为总体设计基线；文件路径已英文化 | 2026-07-14 |
+| 5 | `AI_Agent四项目总体设计规格.md` | `docs/specs/AI_Agent四项目总体设计规格.md` | 规定四个 AI Agent 项目的整体定位、差异化业务范围、技术能力组合、实施顺序和共同约束，是项目组合的最高层设计依据。 | 已冻结为总体设计基线 | 2026-07-14 |
 | 6 | `2026-07-14-agent-portfolio-design.md` | `docs/specs/2026-07-14-agent-portfolio-design.md` | 设计四项目如何组合成求职作品集，包括能力覆盖、展示顺序、共享基础设施边界和避免重复建设的原则。 | 已冻结为组合设计基线 | 2026-07-14 |
 | 7 | `2026-07-14-opercerta-design.md` | `docs/specs/2026-07-14-opercerta-design.md` | OperCerta 原始详细设计，定义业务对象、审批与工单闭环、可靠性要求、技术架构、交付范围和发布门禁，是后续规格审查的基准。 | 已冻结为 OperCerta 详细设计基线 | 2026-07-14 |
 | 8 | `2026-07-15-approval-domain-contract-design.md` | `docs/superpowers/specs/2026-07-15-approval-domain-contract-design.md` | 规定审批请求、业务事实绑定、审批状态转换、并发竞态处理和数据库原子性，防止重复审批或审批旧事实。 | 已确认并实施 | 2026-07-15 |
@@ -62,9 +62,9 @@
 | 54 | `2026-07-16-risk-based-review-and-progress-control.md` | `docs/development-log/decisions/2026-07-16-risk-based-review-and-progress-control.md` | 规定风险分级复核、进度百分比口径、关键节点审批和优先完成纵向业务闭环的项目控制方法。 | 已采用 | 2026-07-16 |
 | 55 | `interview-casebook.md` | `docs/development-log/interview-casebook.md` | 将真实实施问题整理为面试案例，按现象、根因、诊断、修复、验证和经验总结记录可讨论的工程话题。 | 已记录稳定哈希、路由、代理响应等案例并持续扩充 | 2026-07-17 |
 | 56 | `learning-method.md` | `docs/development-log/learning-method.md` | 规定源码阅读、手动命令、单变量实验、复述、故障演练和面试问答结合的项目掌握方法。 | 已加入三业务学习与手动闭环建议；需持续实践 | 2026-07-17 |
-| 57 | `opercerta-core-technical-guide.md` | `docs/learning/opercerta-core-technical-guide.md` | 从一次业务请求出发解释 FastAPI、LangGraph、MCP、PostgreSQL、审批、幂等、恢复、容器和可观测性的代码链路与底层思想。 | 本地学习材料已完成；文件路径已英文化，需结合源码实践 | 2026-07-20 |
-| 58 | `opercerta-manual-experiment-guide.md` | `docs/learning/opercerta-manual-experiment-guide.md` | 提供 WSL2/Compose 启停、三业务操作、数据库核对、MCP 调用、故障注入和恢复验证的可复制命令与观察点。 | 已记录命令；文件路径已英文化，用户掌握检查进行中 | 2026-07-20 |
-| 59 | `opercerta-interview-guide.md` | `docs/learning/opercerta-interview-guide.md` | 提供 30 秒、3 分钟、10 分钟项目介绍、架构解释、技术取舍、可靠性证据和常见追问回答框架。 | 材料已完成；文件路径已英文化，需口述演练和源码补强 | 2026-07-20 |
+| 57 | `OperCerta核心技术手册.md` | `docs/learning/OperCerta核心技术手册.md` | 从一次业务请求出发解释 FastAPI、LangGraph、MCP、PostgreSQL、审批、幂等、恢复、容器和可观测性的代码链路与底层思想。 | 本地学习材料已完成；需结合源码实践 | 2026-07-20 |
+| 58 | `OperCerta手动实验手册.md` | `docs/learning/OperCerta手动实验手册.md` | 提供 WSL2/Compose 启停、三业务操作、数据库核对、MCP 调用、故障注入和恢复验证的可复制命令与观察点。 | 已记录命令；用户掌握检查进行中 | 2026-07-20 |
+| 59 | `OperCerta面试讲解.md` | `docs/learning/OperCerta面试讲解.md` | 提供 30 秒、3 分钟、10 分钟项目介绍、架构解释、技术取舍、可靠性证据和常见追问回答框架。 | 材料已完成；需口述演练和基于源码补强 | 2026-07-20 |
 | 60 | `demo-script.md` | `docs/demo-script.md` | 规定面向 HR 与面试官的展示顺序、演示前检查、业务闭环操作、异常备用方案和诚实边界。 | 静态展示脚本可用；本地三业务演示需按环境复验 | 2026-07-18 |
 | 61 | `approval-atomicity.md` | `docs/release-evidence/approval-atomicity.md` | 保存 PostgreSQL 迁移、审批原子更新、并发批准竞态和业务事实绑定的实际测试命令与结果。 | 本地证据已归档；不代表生产发布 | 2026-07-15 |
 | 62 | `cache-tracing-model-adapter.md` | `docs/release-evidence/cache-tracing-model-adapter.md` | 保存 Redis 只读缓存、审批后绕过、OpenTelemetry 脱敏关联、严格真实模型适配器及未验证边界的阶段证据。 | 阶段证据已归档；真实模型另有独立证据 | 2026-07-20 |
@@ -95,6 +95,7 @@
 | 87 | `task-2-report.md` | `.superpowers/sdd/task-2-report.md` | Task 2 实现报告，记录迁移升降级、原子 Repository、并发一致性、审查修复、数据库回归和最终静态门禁。 | 历史 SDD 实施证据；Task 2 已完成 | 2026-07-16 |
 | 88 | `2026-07-25.md` | `docs/development-log/daily/2026-07-25.md` | 记录掌握检查第 1 关、本地端口排障、异常 signal 收件箱、三类规则发现、PowerShell UUID 422、首屏 JWT/历史信号修复，以及后续历史 signal/operation 启动对账、successor lineage、PostgreSQL 约束名限制、十路重试竞态、Compose 重启和浏览器谱系验证全过程。 | 异常信号、历史对账与后继调查本地门禁通过；新 operation 等待人工审批；未调用本轮 Real Kimi，未 commit/push，生产门禁保持 CLOSED | 2026-07-25 |
 | 89 | `2026-07-26.md` | `docs/development-log/daily/2026-07-26.md` | 记录单根 Agent Loop 纠偏从设计审计到 Task 0–11 的完整实施，覆盖 Agent 回合、统一 Observation、三业务策略、case 工作台、默认运行时、Mock/Compose 门禁、真实 Kimi 兼容故障与文档收口。 | Task 0–11 本地完成；未 commit/push/merge 或公开交互部署；生产门禁保持 CLOSED | 2026-07-26 |
+| 90 | `2026-07-27.md` | `docs/development-log/daily/2026-07-27.md` | 记录 PR #8 合并、main 五项远程门禁、Netlify Preview/Production 两阶段发布、线上资源指纹、静态 API 回退边界、回滚点和下一学习验收任务。 | 静态专题 production deploy `6a6631d24958714a43ddc508` 已通过；公网可写后端未发布，生产门禁保持 CLOSED | 2026-07-27 |
 
 ## Worktree：agent-core-architecture（82 份）
 
@@ -183,7 +184,7 @@
 | 81 | `IMPLEMENTATION_HANDOFF.md` | `.worktrees/agent-core-architecture/IMPLEMENTATION_HANDOFF.md` | 跨对话和上下文压缩后的实施交接文件，记录当前分支、已验证事实、未完成事项、下一步动作及禁止越过的发布边界。（本行登记 agent-core-architecture worktree 中的独立物理文件。） | worktree 分支版本，与根工作树文档存在差异；所属分支：agent-core-architecture | 2026-07-14 |
 | 82 | `README.md` | `.worktrees/agent-core-architecture/README.md` | 项目总入口，说明三业务场景、核心技术栈、运行方式、演示边界、学习入口和发布门禁，供开发者、审阅者与面试官快速了解 OperCerta。（本行登记 agent-core-architecture worktree 中的独立物理文件。） | worktree 分支版本，与根工作树文档存在差异；所属分支：agent-core-architecture | 2026-07-14 |
 
-## Worktree：agent-core-implementation（111 份）
+## Worktree：agent-core-implementation（112 份）
 
 | 序号 | 文件名 | 路径 | 用途（详细） | 状态 | 日期 |
 | ---: | --- | --- | --- | --- | --- |
@@ -298,6 +299,7 @@
 | 109 | `single-root-agent-loop-case-workspace.md` | `.worktrees/agent-core-implementation/docs/release-evidence/single-root-agent-loop-case-workspace.md` | 汇总单根生产入口、三业务新旧等价、后端/前端/静态/Compose 门禁、真实 Kimi 三查询与库存批准、provider 故障零写入及未上线边界。（本行登记 agent-core-implementation worktree 中的独立物理文件。） | 本地 Mock、Compose 与少量 Real 证据通过；Git 与生产发布待审批；所属分支：agent-core-implementation | 2026-07-26 |
 | 110 | `tool-loop-v1.md` | `.worktrees/agent-core-implementation/src/opercerta/prompts/tool-loop-v1.md` | 单根 Agent 每轮 Model↔Tool Observation 的版本化 Prompt，约束模型只能选择当前只读白名单工具或提交引用完整的 Final Analysis，并禁止写工具、对象漂移和隐藏推理输出。（本行登记 agent-core-implementation worktree 中的独立物理文件。） | 已接入 Mock 与真实模型 adapter 并通过代表验证；所属分支：agent-core-implementation | 2026-07-26 |
 | 111 | `2026-07-26.md` | `.worktrees/agent-core-implementation/docs/development-log/daily/2026-07-26.md` | 完整记录单根 Agent Loop 纠偏 Task 0–11、case 工作台、默认运行时、Mock/Compose/Real Kimi 门禁、provider 兼容事故、最终复验和 Git 发布前边界。（本行登记 agent-core-implementation worktree 中的独立物理文件。） | worktree 新增并已完成当日收口；所属分支：agent-core-implementation | 2026-07-26 |
+| 112 | `2026-07-27.md` | `.worktrees/agent-core-implementation/docs/development-log/daily/2026-07-27.md` | 记录 PR #8 合并、main 五项远程门禁、Netlify Preview/Production 两阶段发布、线上资源指纹、静态 API 回退边界、回滚点和下一学习验收任务。（本行登记 agent-core-implementation worktree 中的独立物理文件。） | 发布证据已固化；当前分支：docs/release-readiness-2026-07-27；生产门禁保持 CLOSED | 2026-07-27 |
 
 ## Worktree：github-actions-gate（56 份）
 

--- a/IMPLEMENTATION_HANDOFF.md
+++ b/IMPLEMENTATION_HANDOFF.md
@@ -2,6 +2,8 @@
 
 ## 当前检查点
 
+- 2026-07-27：[PR #8](https://github.com/KXHXK/opercerta/pull/8) 已合并为 `609f8f7`；[main run 30203438564](https://github.com/KXHXK/opercerta/actions/runs/30203438564) 五项门禁全绿，包含完整后端、三业务/Agent 评测和实际 Compose 重启恢复。新版静态专题已从 preview `6a660a8f77aa692302ad00aa` 提升为 production deploy `6a6631d24958714a43ddc508`，线上资源 `index-Ckvsq13U.js` 的 SHA-256 与本地产物一致；上一 production `6a5e0bb5563acf4706a09c0d` 是回滚点。公开站点仍无可写 API；生产 IAM、公网后端、限流、备份、高可用、自动部署和 Release Tag 未完成，门禁 `CLOSED`。下一步进入用户手动演示、源码讲解与面试掌握验收，不启动 ForenTrail。
+
 - 2026-07-26 单根 Agent Loop 与业务对象 case 工作台 Task 0–11 已在本地完成。production runtime 仅构造一个根 LangGraph，三业务共享 Model↔MCP Observation 循环、确定性 Policy、HITL、批准后刷新、Kimi Verifier、binding、幂等写入与 readback；历史图只用于回归/等价测试。最终单元 `395 passed`，受影响隔离 PostgreSQL 集成 `32 passed`；Task 9 完整集成 `260 passed`，前端 19 文件 `60 passed` 且 build，Ruff/format/Mypy（85 个源文件）和仓库安全通过；隔离 Compose 三业务、RAG、数据库和 API/MCP 重启恢复通过。少量真实 Moonshot `kimi-k2.6` 的三业务只读、库存批准写入和无效 provider fail-closed 已通过，修复模型/MCP timeout 耦合、thinking/tool-call 不兼容和 Final/Verifier structured output 波动。证据见 `docs/release-evidence/single-root-agent-loop-case-workspace.md`，事故见 `docs/development-log/incidents/2026-07-26-kimi-tool-loop-compatibility.md`。所有修改尚未 commit/push/merge；公网可写后端与生产 IAM/限流/备份/自动发布仍未完成，门禁 `CLOSED`，不启动 ForenTrail。
 
 - 2026-07-24 已继续收口两项端到端语义：未知后端错误使用固定安全 fallback，不向界面传播原始消息；审批写入成功而后置刷新失败时，UI 保留已提交事实、禁用重复决定并引导 auditor 读取。新鲜门禁为前端 `53 passed` + production build、unit `356 passed`、一次性 pgvector 测试库完整后端 `579 passed in 376.68s`、Ruff/189 文件格式/Mypy 76 个源文件/114 包锁定/仓库安全全绿，以及 Mock release Compose 三业务、Verifier 顺序、数据库事实和 API/MCP 重启恢复退出码 0。Windows `.env.local` 所指测试库未运行且旧凭据在失败 traceback 中再次回显，恢复该库前必须轮换并同步 ignored 配置。本轮修改仍未 commit/push；下一步停在用户审批原子提交，Real Kimi、PR 合并、main Compose 与生产发布未执行，门禁保持 `CLOSED`。

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and audit-focused observability in a reproducible reference implementation.
 
 OperCerta 是面向库存异常、设备告警和运营工单的智能运营处置 Agent 独立作品仓库。
 
-> 当前状态：库存补货、设备维修、作业异常恢复三条 FastAPI + LangGraph + 最小 LangChain + FastMCP + PostgreSQL/pgvector 闭环、演示 JWT/RBAC、Agent Trace、本地 React 控制台和真实 FastEmbed RAG 已有自动化证据。Task 10 历史完整门禁为后端 567 条、前端 46 条、冻结 Agent 轨迹评测 9/9，以及 Compose 三业务/RAG/API-MCP 重启恢复；本轮已修复 Kimi replan 重复工具和 provider 异常 operation 原子收口，新鲜本地回归为 unit 352 条、关键 Agent 图集成 7 条，Draft PR run `29946792369` 完整后端 573 条、三业务评测与 Agent 评测 9/9 通过。Moonshot AI `kimi-k2.6` 完整 Compose 代表验证仍因外部依赖 30 秒有界超时返回安全 503，未回退 Mock 冒充成功。[Draft PR #8](https://github.com/KXHXK/opercerta/pull/8) 的快速 Actions 已全绿，review 与 main-only Compose 尚待完成。新版[零成本静态项目专题](https://opercerta-kxh.netlify.app)和[单页作品集](https://kxh-agent-portfolio.netlify.app)可只读访问；公开页面不提供后端写入口。生产身份、交互 HTTPS 后端、自动部署和公开 API 尚未完成，生产发布门禁：`CLOSED`。
+> 当前状态：库存补货、设备维修、作业异常恢复三条 FastAPI + 单根 LangGraph + 最小 LangChain + FastMCP + PostgreSQL/pgvector 闭环、演示 JWT/RBAC、Agent Trace、本地 React 控制台、Redis 只读证据缓存和真实 FastEmbed RAG 已有自动化证据。少量 Moonshot AI `kimi-k2.6` 代表验证覆盖三业务只读、库存批准写入和无效 provider fail-closed，未回退 Mock 冒充成功。[PR #8](https://github.com/KXHXK/opercerta/pull/8) 已合并为 `609f8f7`，对应 [main CI](https://github.com/KXHXK/opercerta/actions/runs/30203438564) 的仓库安全、Python 质量、完整后端、前端和 Compose 重启恢复全部通过。新版[零成本静态项目专题](https://opercerta-kxh.netlify.app)已于 2026-07-27 发布 deploy `6a6631d24958714a43ddc508`，[单页作品集](https://kxh-agent-portfolio.netlify.app)继续可只读访问；公开页面不提供后端写入口。生产身份、交互 HTTPS 后端、自动部署和公开 API 尚未完成，生产发布门禁：`CLOSED`。
 
 ## 当前已验证范围
 
@@ -40,7 +40,7 @@ OperCerta 是面向库存异常、设备告警和运营工单的智能运营处�
 
 ## 下一实施边界
 
-下一阶段仍只实施 OperCerta。重复工具规划与异常 operation 原子收口已完成并通过 Draft PR 快速 Actions，本地测试数据库密码也已轮换并用 Windows 原生 `psql` 安全验证；下一步完成用户手动演示/口述掌握检查和 PR 合并审批，再执行 main Compose。之后才决定是否建设公网可写 HTTPS 后端。生产 IAM、限流/防滥用、备份、高可用、自动部署和 Release Tag 仍待完成。生产发布门禁为 `CLOSED`，关闭前不启动其他项目。
+下一阶段仍只实施 OperCerta。单根 Agent 纠偏已经合并，main Compose 和新版静态专题生产发布均已通过；下一步完成用户手动演示、源码讲解与口述掌握检查，再整理 Release Tag、简历话术和五分钟演示材料。是否建设公网可写 HTTPS 后端仍需单独选择托管环境并审批成本与安全治理。生产 IAM、限流/防滥用、备份、高可用、自动部署和正式 Release Tag 仍待完成。生产发布门禁为 `CLOSED`，关闭前不启动其他项目。
 
 三业务收口规格与八项 TDD 主计划见 [设计](docs/superpowers/specs/2026-07-20-opercerta-three-business-release-design.md)和[计划](docs/superpowers/plans/2026-07-20-opercerta-three-business-release.md)。历史库存切片设计仍作为可靠性内核演进记录保留。
 

--- a/docs/development-log/current-state.md
+++ b/docs/development-log/current-state.md
@@ -1,5 +1,13 @@
 # OperCerta 当前状态
 
+## 2026-07-27：PR #8、main Compose 与新版静态专题已发布
+
+单根 Agent Loop 与 case 工作台在 [PR #8](https://github.com/KXHXK/opercerta/pull/8) 合并为 `609f8f7dcbfbadb9d12f4371cf49815d48884a4e`。对应 [main run 30203438564](https://github.com/KXHXK/opercerta/actions/runs/30203438564) 的 `repository-safety`、`python-quality`、`backend-tests`、`frontend`、`compose-smoke` 全部成功；Compose 实际完成容器构建启动、Agent 轨迹与数据库副作用、API/MCP 重启、重启恢复和清理。
+
+已验证静态候选 deploy `6a660a8f77aa692302ad00aa`，随后经用户批准发布 production deploy `6a6631d24958714a43ddc508`：<https://opercerta-kxh.netlify.app>。生产根页、独立 deploy URL、`/console` 与 `/api/v1/auth/demo-token` 均为 `200 text/html`；JS 资源为 `index-Ckvsq13U.js`，线上 SHA-256 `dcd31a4d6e1c53f06c1a16cc6fb65f7f5d347926a078dc56fe08606c8052abb1` 与本地候选一致。`/api/*` 返回静态 SPA HTML 是刻意的无后端边界，不代表 API 上线。上一生产 deploy `6a5e0bb5563acf4706a09c0d` 保留为回滚点。
+
+当前完成的是“公开静态求职专题 + 本地可运行完整业务闭环”，不是公网可写生产系统。生产 IAM、公网 HTTPS API、托管 PostgreSQL/Redis、限流、防滥用、备份、高可用、自动部署和正式 Release Tag 仍未完成，发布门禁继续 `CLOSED`。下一步是用户手动运行与源码掌握验收、面试材料和 Release Tag 决策；未完成前不启动 ForenTrail。
+
 ## 2026-07-26 单根 Agent Loop 架构纠偏已批准，Task 0–3 完成
 
 用户在真实控制台复核中指出：当前 LLM 没有形成“决策 → 工具 → Observation → 再决策”的 Agent 核心循环；LangGraph 调查图、Python 包装器和三个场景图被串联使用，完整 operation 并非由一个根图拥有；Redis 也只包裹旧场景初读，没有进入统一的 MCP Observation 链路。前端同时把 predecessor/successor signal 平铺为主卡片，并用全局详情和 busy 状态驱动交互，造成多卡、串卡和业务谱系失真。

--- a/docs/development-log/daily/2026-07-27.md
+++ b/docs/development-log/daily/2026-07-27.md
@@ -1,0 +1,34 @@
+# 2026-07-27 OperCerta 开发日志
+
+## 今日目标
+
+在不开放公网可写后端的边界内，完成单根 Agent 版本的 GitHub 主分支门禁、Netlify 静态专题生产替换和发布证据固化。
+
+## 已观察事实
+
+1. PR #8 在 head `d22d247db2329f81f927866dde4ff3f59d5a2f8d` 上四项快速门禁全绿、可合并状态为 `CLEAN`。
+2. PR #8 合并提交为 `609f8f7dcbfbadb9d12f4371cf49815d48884a4e`。
+3. main run `30203438564` 五个 job 全部成功；Compose 实际验证 Agent 轨迹、数据库副作用、API/MCP 重启和恢复。
+4. 发布相关前端测试 21 条通过，TypeScript/Vite 构建生成 `index-Ckvsq13U.js`。
+5. Preview deploy `6a660a8f77aa692302ad00aa` 经 DOM 验收包含三业务、受控 Agent 技术链路、可靠性证据与诚实边界。
+6. 用户批准后，production deploy `6a6631d24958714a43ddc508` 已发布到 <https://opercerta-kxh.netlify.app>。
+7. 生产根页、`/console`、独立 deploy URL 与 `/api/v1/auth/demo-token` 均为 `200 text/html`；线上 JS SHA-256 与本地产物一致。
+
+## 关键决策
+
+- 使用显式 site id `c9a55c47-8ee1-4d38-be4d-aeb8355cfa74` 和 `--dir web/dist --no-build`，避免工作树解析错误或覆盖个人作品集站点。
+- Preview 先行，用户批准后才执行 production deploy。
+- `/api/*` 的 Netlify HTML 回退只证明静态 SPA 边界；不把它描述为 FastAPI 上线。
+- 上一 production deploy `6a5e0bb5563acf4706a09c0d` 保留为回滚点。
+
+## 验证与限制
+
+- 线上资产：`index-Ckvsq13U.js`。
+- SHA-256：`dcd31a4d6e1c53f06c1a16cc6fb65f7f5d347926a078dc56fe08606c8052abb1`。
+- 本轮未调用 Moonshot/Kimi，未产生新的模型 token 或费用。
+- 未发布 FastAPI、LangGraph、MCP、PostgreSQL、Redis、生产 JWT 或任何密钥。
+- 生产 IAM、公网 HTTPS 后端、限流、防滥用、备份、高可用、自动部署和正式 Release Tag 仍未完成，生产门禁保持 `CLOSED`。
+
+## 下一步
+
+完成用户手动启动、三业务操作、数据库核对、故障注入、源码数据流复述和面试问答验收；依据掌握结果再决定 Release Tag 和简历定稿，不启动 ForenTrail。

--- a/docs/release-evidence/github-actions-ci.md
+++ b/docs/release-evidence/github-actions-ci.md
@@ -1,5 +1,14 @@
 # GitHub Actions 分层 CI：远程验证证据
 
+## 2026-07-27 PR #8 与 main 单根 Agent 总门禁
+
+- [PR #8](https://github.com/KXHXK/opercerta/pull/8) head `d22d247db2329f81f927866dde4ff3f59d5a2f8d` 在合并前状态为 `CLEAN`；PR run [30201946098](https://github.com/KXHXK/opercerta/actions/runs/30201946098) 的 `repository-safety`、`python-quality`、`backend-tests`、`frontend` 全部成功，`compose-smoke` 按 PR 条件跳过。
+- PR 以 merge commit `609f8f7dcbfbadb9d12f4371cf49815d48884a4e` 合入 `main`。
+- 对应 main push run [30203438564](https://github.com/KXHXK/opercerta/actions/runs/30203438564) 结论为 `success`；`repository-safety`、`python-quality`、`backend-tests`、`frontend`、`compose-smoke` 五个 job 全部成功。
+- `backend-tests` 实际依次通过完整后端、三业务契约评测和冻结 Agent 安全/恢复评测。
+- `compose-smoke` 实际依次通过隔离环境创建、服务构建启动、Agent 轨迹与数据库副作用验证、API/MCP 重启、重启后 Agent 恢复和无条件资源清理。失败诊断步骤因总流程成功而按条件跳过。
+- 以上是 GitHub Actions 新鲜远程事实，不用历史 run 或本地结果替代；它证明合并提交的单节点 CI/Compose 发布候选门禁，不代表生产高可用或公网写服务。
+
 ## 范围与仓库可见性
 
 - 核验时间：2026-07-18（Asia/Shanghai）。

--- a/docs/release-evidence/public-portfolio-showcase.md
+++ b/docs/release-evidence/public-portfolio-showcase.md
@@ -1,5 +1,16 @@
 # OperCerta 公开专题部署证据
 
+## 2026-07-27 单根 Agent 版本生产替换
+
+- 对应源码合并提交：`609f8f7dcbfbadb9d12f4371cf49815d48884a4e`；PR：[KXHXK/opercerta#8](https://github.com/KXHXK/opercerta/pull/8)。
+- 发布前本地契约：4 个发布相关测试文件、21 条测试通过；TypeScript/Vite production build 成功。
+- Preview deploy：`6a660a8f77aa692302ad00aa`；浏览器真实读取到三业务、受控 Agent 链路、可靠性证据与诚实边界。
+- Production deploy：`6a6631d24958714a43ddc508`；生产 URL：<https://opercerta-kxh.netlify.app>；[部署日志](https://app.netlify.com/projects/opercerta-kxh/deploys/6a6631d24958714a43ddc508)。
+- `GET /`、`GET /console`、独立 deploy 根页和 `GET /api/v1/auth/demo-token` 均返回 `200 text/html`，共同证明静态 SPA 可访问且没有伪装公开 API。
+- 线上 JS：`index-Ckvsq13U.js`；SHA-256：`dcd31a4d6e1c53f06c1a16cc6fb65f7f5d347926a078dc56fe08606c8052abb1`，与发布前本地候选完全一致。
+- 回滚目标：上一 production deploy `6a5e0bb5563acf4706a09c0d`。Netlify 保留不可变 deploy URL，无需改写 Git 历史。
+- 能力边界：本轮只替换公开静态专题；没有发布 FastAPI、LangGraph、MCP、PostgreSQL、Redis 或模型密钥，也没有把静态回退描述成业务接口。
+
 **核验日期：** 2026-07-18
 
 **证据范围：** 本地 WSL2 Ubuntu、Docker Compose、Vite 控制台、合成库存数据，以及 Netlify 静态生产部署


### PR DESCRIPTION
## What changed

- records PR #8 and the successful `main` CI/Compose gate;
- records the verified Netlify preview and production deploy IDs;
- fixes stale README, current-state and handoff status;
- adds the 2026-07-27 Chinese development log;
- updates the complete document index for the root checkout and implementation worktree.

## Why

The single-root Agent implementation and static showcase were already released, but repository documentation still described PR review, `main` Compose and production promotion as pending. This PR makes the written evidence match the observed GitHub and Netlify state without claiming that the writable backend is public.

## Impact and boundaries

- public static showcase: deployed and verified;
- public writable FastAPI, LangGraph, MCP, PostgreSQL or Redis: not deployed;
- production IAM, rate limiting, backups, high availability, automated deployment and formal Release Tag: still pending;
- OperCerta production gate remains `CLOSED`; ForenTrail remains unstarted.

## Verification

- GitHub `main` run `30203438564`: all five jobs successful, including Compose restart recovery;
- four release-related frontend files: 21 tests passed;
- TypeScript/Vite production build passed;
- production root, `/console`, unique deploy URL and `/api/v1/auth/demo-token`: HTTP 200 HTML;
- production JS SHA-256 matches the locally verified artifact;
- repository safety check passed;
- `git diff --check` passed;
- document inventory: 546 Markdown files, zero missing index entries.

## Rollback

Netlify production deploy `6a5e0bb5563acf4706a09c0d` is the previous immutable deploy and remains the rollback target.
