### PR TITLE
docs: finalize OperCerta release readiness

### DIFF
--- a/DOCUMENT_INDEX.md
+++ b/DOCUMENT_INDEX.md
@@ -27,7 +27,7 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 序号 | 文件名 | 路径 | 用途（详细） | 状态 | 日期 |
 | ---: | --- | --- | --- | --- | --- |
 | 1 | `README.md` | `README.md` | 项目总入口，说明三业务场景、核心技术栈、运行方式、演示边界、学习入口和发布门禁，供开发者、审阅者与面试官快速了解 OperCerta。 | 已同步三业务、本地发布候选、学习入口与剩余门禁 | 2026-07-14 |
-| 2 | `IMPLEMENTATION_HANDOFF.md` | `IMPLEMENTATION_HANDOFF.md` | 跨对话和上下文压缩后的实施交接文件，记录当前分支、已验证事实、未完成事项、下一步动作及禁止越过的发布边界。 | 已同步真实模型验证与公网发布下一边界 | 2026-07-14 |
+| 2 | `IMPLEMENTATION_HANDOFF.md` | `IMPLEMENTATION_HANDOFF.md` | 跨对话和上下文压缩后的实施交接文件，记录当前分支、已验证事实、未完成事项、下一步动作及禁止越过的发布边界。 | 已同步 PR #15、main Compose、换机收口与发布准备分支 | 2026-07-14 |
 | 3 | `DOCUMENT_INDEX.md` | `DOCUMENT_INDEX.md` | OperCerta 全部项目文档的唯一总登记表，用于按文件名、路径、用途、状态和日期统一检索、复查与交接。 | 当前根工作树 115 份文档已完整登记；另保留 6 个旧 worktree 的 456 条历史记录 | 2026-07-15 |
 | 4 | `2026-07-14-agent-project-naming-design.md` | `docs/specs/2026-07-14-agent-project-naming-design.md` | 定义 OperCerta、ForenTrail、SiteVerum、Federune 四个项目的命名原则、语义边界与品牌一致性，防止项目职责和名称漂移。 | 已冻结为命名基线 | 2026-07-14 |
 | 5 | `ai-agent-portfolio-overall-design.md` | `docs/specs/ai-agent-portfolio-overall-design.md` | 规定四个 AI Agent 项目的整体定位、差异化业务范围、技术能力组合、实施顺序和共同约束，是项目组合的最高层设计依据。 | 已冻结为总体设计基线；文件名已统一为英文路径 | 2026-07-14 |
@@ -139,7 +139,7 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 111 | `reporter-v1.md` | `src/opercerta/prompts/reporter-v1.md` | Reporter 角色版本化 Prompt，将已验证事实、工具结果和终态组织为面向业务用户的可解释报告。 | v1 已实施；不得把未验证内容写成事实 | 2026-07-21 |
 | 112 | `tool-loop-v1.md` | `src/opercerta/prompts/tool-loop-v1.md` | Tool Loop 主 Prompt，规定模型在 Observation 后选择继续调用只读工具、请求审批或结束，并约束 JSON 工具协议。 | v1 已用于单根 Agent Loop；真实 Kimi 兼容边界另有事件记录 | 2026-07-26 |
 | 113 | `verifier-v1.md` | `src/opercerta/prompts/verifier-v1.md` | Verifier 角色版本化 Prompt，用于批准后重新核对事实、识别漂移并决定执行、重审批或安全终止。 | v1 已实施并有事实漂移回归测试 | 2026-07-21 |
-| 114 | `2026-07-30.md` | `docs/development-log/daily/2026-07-30.md` | 记录新电脑环境最终收口、WSL 登录 shell Node PATH 的 TDD 修复、冻结依赖国内镜像恢复、DrvFS 权限边界、已有业务卷的幂等语义，以及独立 Compose project 中三业务与重启恢复门禁。 | 环境与隔离候选运行门禁已通过；待提交、PR #15 新鲜 CI、main Compose 和后续发布治理 | 2026-07-30 |
+| 114 | `2026-07-30.md` | `docs/development-log/daily/2026-07-30.md` | 记录新电脑环境最终收口、WSL 登录 shell Node PATH 的 TDD 修复、冻结依赖国内镜像恢复、DrvFS 权限边界、已有业务卷幂等语义、PR 合并态索引故障，以及 main Compose 重启恢复门禁。 | PR #15 已合并，main 五项 CI 与本机四服务健康通过；部署和生产治理待继续 | 2026-07-30 |
 | 115 | `CONTRIBUTING.md` | `CONTRIBUTING.md` | 规定 OperCerta 的分支、最小变更、测试、PR 说明、安全和隐私贡献流程，确保外部协作不引入凭据、客户数据或未经评审的架构扩张。 | 已由 main 的 PR #16 引入；在环境分支同步登记以保证合并态索引一致 | 2026-07-30 |
 
 ## 历史 Worktree：agent-core-architecture（82 条记录）

--- a/DOCUMENT_INDEX.md
+++ b/DOCUMENT_INDEX.md
@@ -26,7 +26,7 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 
 | 序号 | 文件名 | 路径 | 用途（详细） | 状态 | 日期 |
 | ---: | --- | --- | --- | --- | --- |
-| 1 | `README.md` | `README.md` | 项目总入口，说明三业务场景、核心技术栈、运行方式、演示边界、学习入口和发布门禁，供开发者、审阅者与面试官快速了解 OperCerta。 | 已同步三业务、本地发布候选、学习入口与剩余门禁 | 2026-07-14 |
+| 1 | `README.md` | `README.md` | 项目总入口，说明三业务场景、核心技术栈、运行方式、演示边界、学习入口和发布门禁，供开发者、审阅者与面试官快速了解 OperCerta。 | 已同步最新 main 665 条后端、60 条前端、9/9 Agent、Real Kimi 代表范围与剩余门禁 | 2026-07-14 |
 | 2 | `IMPLEMENTATION_HANDOFF.md` | `IMPLEMENTATION_HANDOFF.md` | 跨对话和上下文压缩后的实施交接文件，记录当前分支、已验证事实、未完成事项、下一步动作及禁止越过的发布边界。 | 已同步 PR #15、main Compose、换机收口与发布准备分支 | 2026-07-14 |
 | 3 | `DOCUMENT_INDEX.md` | `DOCUMENT_INDEX.md` | OperCerta 全部项目文档的唯一总登记表，用于按文件名、路径、用途、状态和日期统一检索、复查与交接。 | 当前根工作树 115 份文档已完整登记；另保留 6 个旧 worktree 的 456 条历史记录 | 2026-07-15 |
 | 4 | `2026-07-14-agent-project-naming-design.md` | `docs/specs/2026-07-14-agent-project-naming-design.md` | 定义 OperCerta、ForenTrail、SiteVerum、Federune 四个项目的命名原则、语义边界与品牌一致性，防止项目职责和名称漂移。 | 已冻结为命名基线 | 2026-07-14 |
@@ -83,14 +83,14 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 55 | `interview-casebook.md` | `docs/development-log/interview-casebook.md` | 将真实实施问题整理为面试案例，按现象、根因、诊断、修复、验证和经验总结记录可讨论的工程话题；覆盖 Agent 契约、数据库可靠性、跨平台环境、供应链和发布证据边界。 | 已新增 `.gitattributes` 与既有 CRLF 的差异、冷构建和候选镜像分层举证案例 | 2026-07-17 |
 | 56 | `learning-method.md` | `docs/development-log/learning-method.md` | 规定源码阅读、手动命令、单变量实验、复述、故障演练和面试问答结合的项目掌握方法。 | 已加入三业务学习与手动闭环建议；需持续实践 | 2026-07-17 |
 | 57 | `opercerta-core-technical-guide.md` | `docs/learning/opercerta-core-technical-guide.md` | 从一次业务请求出发解释 FastAPI、LangGraph、MCP、PostgreSQL、审批、幂等、恢复、容器和可观测性的代码链路与底层思想。 | 本地学习材料已完成；文件名已统一为英文路径，需结合源码实践 | 2026-07-20 |
-| 58 | `opercerta-manual-experiment-guide.md` | `docs/learning/opercerta-manual-experiment-guide.md` | 提供 WSL2/Compose 启停、三业务操作、数据库核对、MCP 调用、故障注入和恢复验证的可复制命令与观察点。 | 已记录命令；文件名已统一为英文路径，用户掌握检查待继续 | 2026-07-20 |
-| 59 | `opercerta-interview-guide.md` | `docs/learning/opercerta-interview-guide.md` | 提供 30 秒、3 分钟、10 分钟项目介绍、架构解释、技术取舍、可靠性证据和常见追问回答框架。 | 材料已完成；文件名已统一为英文路径，需口述演练和源码补强 | 2026-07-20 |
-| 60 | `demo-script.md` | `docs/demo-script.md` | 规定面向 HR 与面试官的展示顺序、演示前检查、业务闭环操作、异常备用方案和诚实边界。 | 静态展示脚本可用；本地三业务演示需按环境复验 | 2026-07-18 |
+| 58 | `opercerta-manual-experiment-guide.md` | `docs/learning/opercerta-manual-experiment-guide.md` | 提供 WSL2/Compose 启停、三业务操作、数据库核对、MCP 调用、故障注入和恢复验证的可复制命令与观察点。 | 已同步 signal → case → Agent 调查主流程和根工作树/web 路径；用户掌握检查待继续 | 2026-07-20 |
+| 59 | `opercerta-interview-guide.md` | `docs/learning/opercerta-interview-guide.md` | 提供 30 秒、3 分钟、10 分钟项目介绍、架构解释、技术取舍、可靠性证据和常见追问回答框架。 | 已统一最新 CI 数量与 Real Kimi 先失败后通过口径；需口述演练和源码补强 | 2026-07-20 |
+| 60 | `demo-script.md` | `docs/demo-script.md` | 规定面向 HR 与面试官的展示顺序、演示前检查、业务闭环操作、异常备用方案和诚实边界。 | 已同步扫描异常、case 调查、审批、Verifier 与幂等工单流程；待用户实演 | 2026-07-18 |
 | 61 | `approval-atomicity.md` | `docs/release-evidence/approval-atomicity.md` | 保存 PostgreSQL 迁移、审批原子更新、并发批准竞态和业务事实绑定的实际测试命令与结果。 | 本地证据已归档；不代表生产发布 | 2026-07-15 |
 | 62 | `cache-tracing-model-adapter.md` | `docs/release-evidence/cache-tracing-model-adapter.md` | 保存 Redis 只读缓存、审批后绕过、OpenTelemetry 脱敏关联、严格真实模型适配器及未验证边界的阶段证据。 | 阶段证据已归档；真实模型另有独立证据 | 2026-07-20 |
 | 63 | `demo-jwt-rbac.md` | `docs/release-evidence/demo-jwt-rbac.md` | 保存本地 JWT 签发、四角色权限矩阵、审批身份绑定、安全拒绝和 Compose 回归结果。 | 本地验证通过；不代表生产身份系统 | 2026-07-18 |
 | 64 | `docker-linux-runtime.md` | `docs/release-evidence/docker-linux-runtime.md` | 保存 WSL2 Ubuntu 下 Compose 构建、服务健康、数据库初始化、业务 smoke 和重启恢复的实际输出。 | 单节点本地验证通过；发布门禁仍关闭 | 2026-07-17 |
-| 65 | `github-actions-ci.md` | `docs/release-evidence/github-actions-ci.md` | 保存 GitHub PR/main Actions、后端与前端测试、PostgreSQL/Compose smoke、仓库可见性变化和分支保护能力核验。 | 远程 CI 已通过；main 保护尚未配置 | 2026-07-18 |
+| 65 | `github-actions-ci.md` | `docs/release-evidence/github-actions-ci.md` | 保存 GitHub PR/main Actions、后端与前端测试、PostgreSQL/Compose smoke、仓库可见性变化和分支保护能力核验。 | 已追加 PR #15、main run 30525556998、665/60/9-of-9 与 Compose 重启恢复证据；main 保护尚未配置 | 2026-07-18 |
 | 66 | `inventory-replenishment-vertical-slice.md` | `docs/release-evidence/inventory-replenishment-vertical-slice.md` | 汇总库存查询、规则判断、审批、执行、唯一工单、审计和 API 的首条端到端后端闭环证据。 | Windows 本地后端闭环已验证；发布门禁仍关闭 | 2026-07-16 |
 | 67 | `langgraph-restart-recovery.md` | `docs/release-evidence/langgraph-restart-recovery.md` | 保存 LangGraph 四点 A/B 重启测试、checkpointer 状态、审批中断恢复和副作用不重复的数据库断言。 | 本地恢复证据已归档；不代表生产高可用 | 2026-07-16 |
 | 68 | `native-postgres-environment.md` | `docs/release-evidence/native-postgres-environment.md` | 保存 Windows 原生 PostgreSQL 版本、服务、数据库、角色、认证规则和连接验证结果。 | 历史环境证据已归档；当前主运行时已迁移 | 2026-07-15 |
@@ -139,7 +139,7 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 111 | `reporter-v1.md` | `src/opercerta/prompts/reporter-v1.md` | Reporter 角色版本化 Prompt，将已验证事实、工具结果和终态组织为面向业务用户的可解释报告。 | v1 已实施；不得把未验证内容写成事实 | 2026-07-21 |
 | 112 | `tool-loop-v1.md` | `src/opercerta/prompts/tool-loop-v1.md` | Tool Loop 主 Prompt，规定模型在 Observation 后选择继续调用只读工具、请求审批或结束，并约束 JSON 工具协议。 | v1 已用于单根 Agent Loop；真实 Kimi 兼容边界另有事件记录 | 2026-07-26 |
 | 113 | `verifier-v1.md` | `src/opercerta/prompts/verifier-v1.md` | Verifier 角色版本化 Prompt，用于批准后重新核对事实、识别漂移并决定执行、重审批或安全终止。 | v1 已实施并有事实漂移回归测试 | 2026-07-21 |
-| 114 | `2026-07-30.md` | `docs/development-log/daily/2026-07-30.md` | 记录新电脑环境最终收口、WSL 登录 shell Node PATH 的 TDD 修复、冻结依赖国内镜像恢复、DrvFS 权限边界、已有业务卷幂等语义、PR 合并态索引故障，以及 main Compose 重启恢复门禁。 | PR #15 已合并，main 五项 CI 与本机四服务健康通过；部署和生产治理待继续 | 2026-07-30 |
+| 114 | `2026-07-30.md` | `docs/development-log/daily/2026-07-30.md` | 记录新电脑环境最终收口、WSL 登录 shell Node PATH 的 TDD 修复、冻结依赖国内镜像恢复、DrvFS 权限边界、PR/main 门禁，以及发布材料防漂移与静态安全头修订。 | PR #15/main 五项 CI 与本机四服务健康通过；求职材料口径已校正，公网安全头待部署验证 | 2026-07-30 |
 | 115 | `CONTRIBUTING.md` | `CONTRIBUTING.md` | 规定 OperCerta 的分支、最小变更、测试、PR 说明、安全和隐私贡献流程，确保外部协作不引入凭据、客户数据或未经评审的架构扩张。 | 已由 main 的 PR #16 引入；在环境分支同步登记以保证合并态索引一致 | 2026-07-30 |
 
 ## 历史 Worktree：agent-core-architecture（82 条记录）

--- a/DOCUMENT_INDEX.md
+++ b/DOCUMENT_INDEX.md
@@ -97,7 +97,7 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 69 | `observability-security-regression.md` | `docs/release-evidence/observability-security-regression.md` | 保存 request_id、结构化安全日志、低基数指标、敏感信息防泄漏、HTTP/SSE 和全量回归结果。 | 本地门禁通过；生产发布门禁仍关闭 | 2026-07-18 |
 | 70 | `performance-cache-matrix.md` | `docs/release-evidence/performance-cache-matrix.md` | 记录缓存开关与工具模式组成的 12 格、60 次 query 的实际 MCP 调用、cache hit 和本机延迟。 | 本机小样本已测；明确不作生产性能承诺 | 2026-07-20 |
 | 71 | `portfolio-netlify-static-mirror.md` | `docs/release-evidence/portfolio-netlify-static-mirror.md` | 保存原 Sites 403 对照、静态导出测试、Netlify preview/production deploy id、HTTPS 和浏览器核验。 | 公开作品集静态镜像已验证；业务后端仍未公开 | 2026-07-19 |
-| 72 | `public-portfolio-showcase.md` | `docs/release-evidence/public-portfolio-showcase.md` | 保存 OperCerta 静态专题、库存审批示例、唯一工单、审计序列、截图、资源指纹和线上 URL 验证。 | 静态 URL 已验证；原业务发布门禁仍关闭 | 2026-07-18 |
+| 72 | `public-portfolio-showcase.md` | `docs/release-evidence/public-portfolio-showcase.md` | 保存 OperCerta 静态专题、库存审批示例、唯一工单、审计序列、截图、资源指纹和线上 URL 验证。 | 安全头 Preview 已验证；production 晋级待主线门禁，原业务发布门禁仍关闭 | 2026-07-30 |
 | 73 | `real-model-representative-validation.md` | `docs/release-evidence/real-model-representative-validation.md` | 保存 Moonshot AI kimi-k2.6 在三业务中的代表性模型调用、兼容调试、端到端耗时和敏感信息边界。 | 本地 6 次代表操作通过；公网和生产仍关闭 | 2026-07-20 |
 | 74 | `reliability-kernel.md` | `docs/release-evidence/reliability-kernel.md` | 汇总非法输入、状态恢复、审批竞态、幂等工单和数据库断言等 Task 1–6 可靠性内核门禁。 | 本地可靠性内核已验证；发布门禁仍关闭 | 2026-07-16 |
 | 75 | `replenishment-contract-evaluation.md` | `docs/release-evidence/replenishment-contract-evaluation.md` | 保存 30 条冻结库存补货合成契约的逐例结果、全量回归和明确的非模型准确率、非生产效果边界。 | 30 条本地契约全部通过；不代表独立评测 | 2026-07-18 |
@@ -139,7 +139,7 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 111 | `reporter-v1.md` | `src/opercerta/prompts/reporter-v1.md` | Reporter 角色版本化 Prompt，将已验证事实、工具结果和终态组织为面向业务用户的可解释报告。 | v1 已实施；不得把未验证内容写成事实 | 2026-07-21 |
 | 112 | `tool-loop-v1.md` | `src/opercerta/prompts/tool-loop-v1.md` | Tool Loop 主 Prompt，规定模型在 Observation 后选择继续调用只读工具、请求审批或结束，并约束 JSON 工具协议。 | v1 已用于单根 Agent Loop；真实 Kimi 兼容边界另有事件记录 | 2026-07-26 |
 | 113 | `verifier-v1.md` | `src/opercerta/prompts/verifier-v1.md` | Verifier 角色版本化 Prompt，用于批准后重新核对事实、识别漂移并决定执行、重审批或安全终止。 | v1 已实施并有事实漂移回归测试 | 2026-07-21 |
-| 114 | `2026-07-30.md` | `docs/development-log/daily/2026-07-30.md` | 记录新电脑环境最终收口、WSL 登录 shell Node PATH 的 TDD 修复、冻结依赖国内镜像恢复、DrvFS 权限边界、PR/main 门禁，以及发布材料防漂移与静态安全头修订。 | PR #15/main 五项 CI 与本机四服务健康通过；求职材料口径已校正，公网安全头待部署验证 | 2026-07-30 |
+| 114 | `2026-07-30.md` | `docs/development-log/daily/2026-07-30.md` | 记录新电脑环境最终收口、WSL 登录 shell Node PATH 的 TDD 修复、冻结依赖国内镜像恢复、DrvFS 权限边界、PR/main 门禁，以及发布材料防漂移与静态安全头修订。 | PR #15/main 五项 CI 与本机四服务健康通过；求职材料口径已校正，Netlify Preview 安全头及产物一致性已验证，production 晋级待主线门禁 | 2026-07-30 |
 | 115 | `CONTRIBUTING.md` | `CONTRIBUTING.md` | 规定 OperCerta 的分支、最小变更、测试、PR 说明、安全和隐私贡献流程，确保外部协作不引入凭据、客户数据或未经评审的架构扩张。 | 已由 main 的 PR #16 引入；在环境分支同步登记以保证合并态索引一致 | 2026-07-30 |
 
 ## 历史 Worktree：agent-core-architecture（82 条记录）

--- a/IMPLEMENTATION_HANDOFF.md
+++ b/IMPLEMENTATION_HANDOFF.md
@@ -2,6 +2,8 @@
 
 ## 当前检查点
 
+- 2026-07-30：换机环境分支经 [PR #15](https://github.com/KXHXK/opercerta/pull/15) 合并为 main 提交 `42ba974`；对应 [main run 30525556998](https://github.com/KXHXK/opercerta/actions/runs/30525556998) 的 repository-safety、python-quality、frontend、backend-tests 和实际 compose-smoke 全部成功。compose-smoke 已执行镜像构建、三业务 Agent 轨迹与数据库副作用、API/MCP 重启、恢复验证和隔离卷清理。本地 main 已 fast-forward 到同一提交；WSL 的 Node `24.18.0`、npm `11.16.0`、uv `0.11.28` 可用，PostgreSQL/Redis/MCP/API 四服务均 healthy，readiness 为 database/checkpoint/MCP 全部 ready。当前后续分支为 `chore/release-readiness-20260730`，用于部署、评测、源码掌握和简历材料收口；公网可写后端和生产 IAM/限流/备份仍未实现，production release gate 保持 `CLOSED`，不启动 ForenTrail。
+
 - 2026-07-27：[PR #8](https://github.com/KXHXK/opercerta/pull/8) 已合并为 `609f8f7`；[main run 30203438564](https://github.com/KXHXK/opercerta/actions/runs/30203438564) 五项门禁全绿，包含完整后端、三业务/Agent 评测和实际 Compose 重启恢复。新版静态专题已从 preview `6a660a8f77aa692302ad00aa` 提升为 production deploy `6a6631d24958714a43ddc508`，线上资源 `index-Ckvsq13U.js` 的 SHA-256 与本地产物一致；上一 production `6a5e0bb5563acf4706a09c0d` 是回滚点。公开站点仍无可写 API；生产 IAM、公网后端、限流、备份、高可用、自动部署和 Release Tag 未完成，门禁 `CLOSED`。下一步进入用户手动演示、源码讲解与面试掌握验收，不启动 ForenTrail。
 
 - 2026-07-26 单根 Agent Loop 与业务对象 case 工作台 Task 0–11 已在本地完成。production runtime 仅构造一个根 LangGraph，三业务共享 Model↔MCP Observation 循环、确定性 Policy、HITL、批准后刷新、Kimi Verifier、binding、幂等写入与 readback；历史图只用于回归/等价测试。最终单元 `395 passed`，受影响隔离 PostgreSQL 集成 `32 passed`；Task 9 完整集成 `260 passed`，前端 19 文件 `60 passed` 且 build，Ruff/format/Mypy（85 个源文件）和仓库安全通过；隔离 Compose 三业务、RAG、数据库和 API/MCP 重启恢复通过。少量真实 Moonshot `kimi-k2.6` 的三业务只读、库存批准写入和无效 provider fail-closed 已通过，修复模型/MCP timeout 耦合、thinking/tool-call 不兼容和 Final/Verifier structured output 波动。证据见 `docs/release-evidence/single-root-agent-loop-case-workspace.md`，事故见 `docs/development-log/incidents/2026-07-26-kimi-tool-loop-compatibility.md`。所有修改尚未 commit/push/merge；公网可写后端与生产 IAM/限流/备份/自动发布仍未完成，门禁 `CLOSED`，不启动 ForenTrail。
@@ -65,7 +67,7 @@
 ## 新对话必须先做
 
 1. 先阅读 `DOCUMENT_INDEX.md`、`docs/development-log/current-state.md` 和最近每日日志，再阅读相关设计、计划、交接和 Git 状态。
-2. 只实施 OperCerta；规格一致性本地修复尚未 commit/push，下一步先由用户审查并批准提交，再运行 Draft PR 快速 Actions；之后才进入用户掌握检查、合并审批和 main Compose。生产门禁关闭前不启动其他项目。
+2. 只实施 OperCerta；换机环境 PR #15 与 main Compose 已全绿。下一步在 `chore/release-readiness-20260730` 先复核部署目标、公开边界与剩余生产治理，再依次完成部署/readiness、固定评测、源码掌握和简历材料。生产门禁关闭前不启动其他项目。
 3. 运行集成测试前，以不回显方式从已忽略 `.env.local` 加载 `OPERCERTA_DATABASE_URL`；不得提交该文件或任何凭据。
 4. 每个效果数字都保留基线、测试数据、测量脚本和结果证据；指标未测出前使用目标值或空值，不写成已实现结果。
 5. 使用公开或合成数据，从零编写全部代码和文档，不导入任何原单位源码、数据、截图、模型、品牌或内部规则。
@@ -79,4 +81,4 @@
 
 ## 可复制到新对话的启动语
 
-> 工作目录为本 OperCerta 仓库根目录。请先读取 `DOCUMENT_INDEX.md`、`docs/development-log/current-state.md`、最近每日日志、`README.md`、`IMPLEMENTATION_HANDOFF.md`、`docs/specs/` 下的四份设计文件及当前相关规格、计划和证据；Agent 核心 Draft PR #8 既有快速 Actions 已全绿，规格一致性本地修复尚未 commit/push，Real Kimi 完整 Compose 路径仍为 failed。下一步先审查并批准本地修复提交，再跑 PR CI、用户手动演示/口述掌握检查、合并审批和 main Compose。公开根路径只读、`/engineering` 仅 localhost、`/console` 仅本地真实演示；不复用旧公司材料，不虚构指标，不启动其他项目。
+> 工作目录为本 OperCerta 仓库根目录。请先读取 `DOCUMENT_INDEX.md`、`docs/development-log/current-state.md`、最近每日日志、`README.md`、`IMPLEMENTATION_HANDOFF.md`、`docs/specs/` 下的四份设计文件及当前相关规格、计划和证据；换机环境 PR #15 已合并为 main `42ba974`，main run `30525556998` 五项全绿并包含真实 Compose 构建、三业务数据库副作用和重启恢复，本机四服务 healthy。当前分支 `chore/release-readiness-20260730` 继续部署、评测、源码掌握和简历材料收口。公开根路径只读、`/engineering` 仅 localhost、`/console` 仅本地真实演示；不复用旧公司材料，不虚构指标，不启动其他项目。

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and audit-focused observability in a reproducible reference implementation.
 
 OperCerta 是面向库存异常、设备告警和运营工单的智能运营处置 Agent 独立作品仓库。
 
-> 当前状态：库存补货、设备维修、作业异常恢复三条 FastAPI + 单根 LangGraph + 最小 LangChain + FastMCP + PostgreSQL/pgvector 闭环、演示 JWT/RBAC、Agent Trace、本地 React 控制台、Redis 只读证据缓存和真实 FastEmbed RAG 已有自动化证据。少量 Moonshot AI `kimi-k2.6` 代表验证覆盖三业务只读、库存批准写入和无效 provider fail-closed，未回退 Mock 冒充成功。[PR #8](https://github.com/KXHXK/opercerta/pull/8) 已合并为 `609f8f7`，对应 [main CI](https://github.com/KXHXK/opercerta/actions/runs/30203438564) 的仓库安全、Python 质量、完整后端、前端和 Compose 重启恢复全部通过。新版[零成本静态项目专题](https://opercerta-kxh.netlify.app)已于 2026-07-27 发布 deploy `6a6631d24958714a43ddc508`，[单页作品集](https://kxh-agent-portfolio.netlify.app)继续可只读访问；公开页面不提供后端写入口。生产身份、交互 HTTPS 后端、自动部署和公开 API 尚未完成，生产发布门禁：`CLOSED`。
+> 当前状态：库存补货、设备维修、作业异常恢复三条 FastAPI + 单根 LangGraph + 最小 LangChain + FastMCP + PostgreSQL/pgvector 闭环、演示 JWT/RBAC、Agent Trace、本地 React 控制台、Redis 只读证据缓存和真实 FastEmbed RAG 已有自动化证据。少量 Moonshot AI `kimi-k2.6` 代表验证覆盖三业务只读、库存批准写入和无效 provider fail-closed，未回退 Mock 冒充成功。[PR #8](https://github.com/KXHXK/opercerta/pull/8) 合入单根 Agent 架构；最新 [main CI](https://github.com/KXHXK/opercerta/actions/runs/30525556998) 在 `42ba974` 上通过 665 条后端测试、19 个前端测试文件/60 条用例、9/9 冻结 Agent 评测和真实 Compose 构建、三业务数据库副作用与 API/MCP 重启恢复。新版[零成本静态项目专题](https://opercerta-kxh.netlify.app)已于 2026-07-27 发布 deploy `6a6631d24958714a43ddc508`，[单页作品集](https://kxh-agent-portfolio.netlify.app)继续可只读访问；公开页面不提供后端写入口。生产身份、交互 HTTPS 后端、自动部署和公开 API 尚未完成，生产发布门禁：`CLOSED`。
 
 ## 当前已验证范围
 
@@ -32,11 +32,11 @@ OperCerta 是面向库存异常、设备告警和运营工单的智能运营处�
 - 服务端 UUIDv4 request_id、异常后上下文清理、安全 JSON 日志、应用级低基数 Prometheus 指标、SSE 实际回放计数，以及默认关闭的 `/metrics`。
 - Public GitHub remote、只读且固定 Action SHA 的四个 PR 快速门禁，以及 `main` 上实际通过的 Compose 业务 smoke、API/MCP 重启恢复和无条件清理。
 - Netlify 公开静态专题、真实部署资源指纹和证据图片响应验证；该站点不连接 API、数据库或 MCP。
-- 历史解释型 adapter 曾完成 Moonshot AI `kimi-k2.6` 三业务代表运行；新 Plan-and-Execute Agent 的 Real Kimi Tool Calling 报告为 failed，不能沿用旧结果声称新架构已通过。报告不保存模型原文，provider 未返回 usage 时不估算 token/成本。
+- 新 Plan-and-Execute Agent 的 Real Kimi 首轮三业务报告为 failed；修复模型/MCP timeout 耦合、thinking/tool-call 兼容和内部结构化提交边界后，三业务只读、库存批准写入和无效 provider fail-closed 代表路径通过。首轮失败报告继续保留为修复前证据；少量通过不解释为准确率、SLA 或成本指标。
 - 冻结 Agent 轨迹评测 9/9，覆盖非法 schema、提示注入、未知工具、对象漂移、RAG 隔离、批准后事实漂移、审批竞态、幂等写入与关键重启；这不是生产准确率。
-- 零成本展示门禁：前端 16 个测试文件/40 条测试、后端 430 条测试、Ruff、138 文件格式、mypy 62 个源码文件和仓库安全检查全部通过；Mock release Compose 从全新卷启动并完成 API/MCP 重启恢复；1440/768/390 三档浏览器检查无项目固定模块、横向溢出、坏图或控制台告警；新版专题和作品集已经两阶段 Netlify 发布并完成生产 HTTP/浏览器核验。
+- 最新 main 求职展示门禁：后端 665 条测试、前端 19 个测试文件/60 条用例、三业务契约评测、冻结 Agent 评测 9/9、Ruff、mypy、仓库安全和 Compose 重启恢复全部通过；公开专题与本机构建 JS 的 SHA-256 一致。固定用例只证明已声明的合成契约，不是生产准确率或 SLA。
 
-新 Agent 核心的本地通过项与 Real Kimi 失败边界见 [Agent 核心架构交付证据](docs/release-evidence/agent-core-architecture.md)。旧三业务评测、Compose、缓存与解释型模型证据保留为历史阶段证据，不能替代新架构验证。中文学习入口为 [核心技术手册](docs/learning/opercerta-core-technical-guide.md)、[手动实验手册](docs/learning/opercerta-manual-experiment-guide.md)和[面试讲解](docs/learning/opercerta-interview-guide.md)。这些不是生产 IAM、交互 HTTPS 后端或公开 API 完成声明。
+新 Agent 核心的修复前失败边界见 [Agent 核心架构交付证据](docs/release-evidence/agent-core-architecture.md)，修复后的单根路径与真实 Kimi 代表通过项见 [单根 Agent Loop 与 Case 工作台证据](docs/release-evidence/single-root-agent-loop-case-workspace.md)。旧阶段报告保留为时间顺序证据，不能覆盖后续结果。中文学习入口为 [核心技术手册](docs/learning/opercerta-core-technical-guide.md)、[手动实验手册](docs/learning/opercerta-manual-experiment-guide.md)和[面试讲解](docs/learning/opercerta-interview-guide.md)。这些不是生产 IAM、交互 HTTPS 后端或公开 API 完成声明。
 
 ## 下一实施边界
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -2,14 +2,14 @@
 
 本脚本只使用本地合成数据，目标时长 5--8 分钟。公开专题可即时打开；真实交互前确认本地 Docker Compose 健康，并准备 `http://localhost:5173/engineering` 与 `http://localhost:5173/console`。`/engineering` 不部署到公开主机。
 
-1. 先打开公开项目专题，说明三业务是库存补货、设备维修、作业异常恢复，并指出交互生产发布门禁仍为 `CLOSED`。
-2. 面试官追问技术时打开本地 `/engineering`：用 10 步链路说明 React → FastAPI → PostgreSQL Operation → LangGraph → FastMCP/Redis/Kimi → 审批恢复 → 幂等工单 → SSE；再用三业务差异矩阵说明共享可靠性内核与类型化变化点。
-3. 切换到 `/console`，选择一个场景和 `operator`；先执行“查询状态”，展示 completed、零审批、零工单，再执行“创建处置”进入等待审批。
-4. 切换到 `approver`，提交绑定审批；展示审批绑定中的证据、规则版本、事实哈希、计划哈希和建议参数均来自后端事实，调用者不能提交审批身份。
-5. 审批通过后展示最终状态、唯一工单 ID 和审计时间线；强调重复请求复用同一工单，而不是生成第二条写入。
-6. 解释两项自动化证据：PostgreSQL 行锁让并发审批只有一个原子胜者；API/MCP 重启后从业务表与 LangGraph checkpoint 恢复。
-7. 展示 Mock/Real 分离证据：Mock Agent + 真实 FastEmbed/pgvector RAG 的 9/9 轨迹评测和 Compose 重启已通过；新 Agent 核心的 Real Kimi Tool Calling 代表 query 为 failed。说明低层 tool probe 与完整端到端兼容是两种证据，失败未回退 Mock，原文/token/费用没有被虚构记录。
-8. 如面试官追问工程排障，从 `/engineering` 的事故复盘选择 1--2 个案例，按“观察—根因—修复—验证—限制”讲述，不逐项念页面。
-9. 结束时明确边界：真实 Kimi 新 Agent 路径仍需兼容修复；生产 IAM/SSO、公开交互 HTTPS 后端、自动部署和 Release Tag 尚未完成，公开专题不提供可写服务。
+1. 先打开公开项目专题，说明三业务是库存补货、设备维修、作业异常恢复；公开页面用于即时招聘展示，公网可写生产门禁仍为 `CLOSED`。
+2. 面试官追问技术时打开本地 `/engineering`：用 10 步链路说明 React → FastAPI → PostgreSQL signal/operation → 单根 LangGraph → FastMCP/Redis/Kimi → HITL → Verifier → 幂等工单 → Trace/SSE；再用三业务矩阵说明共享可靠性内核与类型化变化点。
+3. 切换到 `/console`，保持 `operator`，点击“扫描业务异常”。说明固定演示监控清单对三个合成对象执行 6 次只读 MCP 调用和确定性规则，只有检测到异常才生成 case，不让 LLM 猜测是否异常。
+4. 选择一张“待调查”case，点击“启动 Agent 调查”。展示编码后的 Goal、Model↔Tool Observation、SOP citation、模型建议与确定性计划，并确认 LangGraph 停在 `awaiting_approval`。
+5. 切换到 `approver`，核对并提交绑定审批；说明证据 ID、规则版本、事实哈希、计划哈希和参数来自后端，审批身份来自演示 JWT，调用者不能在请求体冒充审批人。
+6. 审批通过后展示 Verifier、最终状态、唯一工单 ID、写后读和审计时间线；切换 `auditor` 读取同一处置，强调 Trace、业务 audit 和 OpenTelemetry 的职责不同。
+7. 解释两项自动化证据：PostgreSQL 行锁让并发审批只有一个原子胜者；API/MCP 重启后由业务表寻找候选、LangGraph checkpoint 决定续跑位置，重复执行仍复用同一幂等工单。
+8. 展示 Mock/Real 分层证据：Mock 冻结评测 9/9 和真实 FastEmbed/pgvector、PostgreSQL、MCP、Compose 重启通过；新单根 Agent 的 Real Kimi 三业务只读、库存批准写入和无效 provider fail-closed 代表路径通过。修复前 failed 报告仍保留，少量调用不解释为准确率、SLA、token 或成本指标。
+9. 如面试官追问工程排障，从 `/engineering` 选择 1--2 个案例，按“观察—根因—修复—验证—限制”讲述。结束时主动说明生产 IAM/SSO、公网可写 HTTPS 后端、限流、备份、高可用、自动部署和 Release Tag 尚未完成。
 
 录制视频时只保留浏览器业务区域，不展示本机用户名、文件路径、令牌、数据库连接或环境变量。只有实际完成上述流程的录屏才能放入公开专题；失败或未验证的运行不得剪辑成成功结果。

--- a/docs/development-log/current-state.md
+++ b/docs/development-log/current-state.md
@@ -1,6 +1,12 @@
 # OperCerta 当前状态
 
-## 2026-07-30：换机环境已完成隔离业务门禁，等待 PR #15 新鲜 CI
+## 2026-07-30：换机环境已合并 main，远程与本机 Compose 门禁通过
+
+PR #15 已以普通 merge commit 合并为 main `42ba974`，未删除分支、未强推、未绕过门禁。对应 main run `30525556998` 五个 job 全部成功：repository-safety、python-quality、frontend、backend-tests，以及只在 main push 执行的 compose-smoke。compose-smoke 真实完成镜像构建启动、Agent 轨迹与数据库副作用验证、API/MCP 重启、恢复验证和隔离卷清理。
+
+本地主线已 fast-forward 到同一提交，随后从干净 main 创建 `chore/release-readiness-20260730` 作为下一阶段分支。WSL 登录 shell 可直接使用 Node `24.18.0`、npm `11.16.0` 和 uv `0.11.28`；使用已有已验证镜像且不删除数据卷恢复本机 Compose 后，PostgreSQL、Redis、MCP、API 四服务均 healthy，`/health/ready` 返回 database/checkpoint/MCP 全部 ready。换机环境阶段至此关闭。
+
+下一阶段依次为部署边界复核、公开环境 readiness、固定评测、源码级掌握和简历材料。现有 Netlify 是只读静态专题；公网可写后端、生产身份、限流、备份、高可用和自动部署仍未完成，因此 production release gate 继续 `CLOSED`，不启动 ForenTrail。
 
 当前分支 `chore/new-machine-env-20260729` 与远端同名分支在本轮修改前为 `ahead 0 / behind 0`，Draft PR #15 的 repository-safety、python-quality、backend-tests、frontend 已有绿色基线。新电脑固定工具链为 WSL2 Ubuntu 26.04、uv `0.11.28`、项目 Python `3.12.13`、Node `24.18.0`、npm `11.16.0`、Docker `29.1.3` 和 Compose `2.40.3`。
 

--- a/docs/development-log/daily/2026-07-30.md
+++ b/docs/development-log/daily/2026-07-30.md
@@ -92,3 +92,13 @@ Node PATH 只写入 `.bashrc`。Ubuntu 的 `.bashrc` 对非交互 shell 会提�
 本轮提交 `503d447` 推送后，PR #15 的 repository-safety、python-quality 和 frontend 通过，backend-tests 报告 `2 failed, 663 passed`。两条失败都是同一根因：PR 合并态基于最新 `main`，而 `main` 的 PR #16 新增了 `CONTRIBUTING.md`；当前环境分支本地基线尚未取得该提交，因此本地索引看到 114 份文档，GitHub 合并态看到 115 份。
 
 GitHub compare API 证明 `1ff234c...main` 的净文件变化只有新增 `CONTRIBUTING.md`，对应提交 `f3bcd60` 和合并提交 `d1d1798`。Git 原生 HTTPS 连续发生 connection reset、empty reply 和 443 timeout 后，没有使用 force push，也没有伪造其他文件；改由已认证 GitHub API 读取 main 的原始文件内容，在当前分支建立完全相同的 `CONTRIBUTING.md`，并将索引计数和第 115 行同步。随后必须先在本地复现 115/115，再推送重新触发完整后端 CI。
+
+## PR 合并与 main 门禁最终结果
+
+- 本地定向复验为 `10 passed`，文档索引 `115/115`，仓库安全扫描通过；本地 `CONTRIBUTING.md` 与 main 原文件的 Git blob SHA 完全一致。
+- Git HTTPS push 连续失败后，使用 GitHub Git Data API 上传并逐个核对三个文档 blob 和完整 tree；远端引用更新前再次确认父提交未变化，并以 `force=false` 做 fast-forward。API 生成 commit 与本地通过原始对象 SHA 对齐为 `7c14c54`，本地和远端未形成分叉。
+- PR #15 第二轮 repository-safety、python-quality、frontend、backend-tests 全部通过；backend-tests 耗时约 2 分 29 秒。PR 随后转为 Ready 并经用户批准，以普通 merge commit 合并为 main `42ba974`。
+- main run `30525556998` 五项全部通过。backend-tests 完成完整后端、三业务契约评测和冻结 Agent 安全/恢复评测；compose-smoke 实际执行镜像构建、Agent 轨迹与数据库副作用、API/MCP 重启、恢复验证及隔离卷清理。
+- 本地 main 已 fast-forward 到 `42ba974`。使用已有镜像执行 `docker compose up -d --no-build`，未删除原开发卷；PostgreSQL、Redis、MCP、API 四服务最终全部 healthy，readiness 返回 database/checkpoint/MCP 均为 ready。
+
+换机环境实施至此完成。下一阶段从干净 main 创建 `chore/release-readiness-20260730`，只继续 OperCerta 的部署、评测、源码掌握和简历材料；production release gate 仍为 `CLOSED`。

--- a/docs/development-log/daily/2026-07-30.md
+++ b/docs/development-log/daily/2026-07-30.md
@@ -102,3 +102,12 @@ GitHub compare API 证明 `1ff234c...main` 的净文件变化只有新增 `CONTR
 - 本地 main 已 fast-forward 到 `42ba974`。使用已有镜像执行 `docker compose up -d --no-build`，未删除原开发卷；PostgreSQL、Redis、MCP、API 四服务最终全部 healthy，readiness 返回 database/checkpoint/MCP 均为 ready。
 
 换机环境实施至此完成。下一阶段从干净 main 创建 `chore/release-readiness-20260730`，只继续 OperCerta 的部署、评测、源码掌握和简历材料；production release gate 仍为 `CLOSED`。
+
+## 发布准备审计与求职材料防漂移
+
+- 公网即时核验：`https://opercerta-kxh.netlify.app` 与 `https://kxh-agent-portfolio.netlify.app` 均返回 HTTPS 200；本次请求总时间分别约 0.28 秒和 0.35 秒。OperCerta 公网 JS `index-Ckvsq13U.js` 为 254,845 bytes，SHA-256 与本机最新构建完全一致。
+- 审计发现求职材料仍混有 2026-07-22 修复前状态：旧演示脚本按“查询状态 → 直接创建处置”描述，面试稿一处称新 Kimi 路径失败、后文又称代表路径通过，且手动手册仍引用旧 worktree 和不存在的 `frontend` 目录。
+- 当前唯一口径来自 2026-07-26 单根 Agent 证据和最新 main 日志：Real Kimi 代表范围为三业务只读、库存批准写入、无效 provider fail-closed；首轮 failed 报告保留为修复前证据。main 为后端 665 条、前端 19 文件/60 条、Agent 9/9；这些不是生产准确率、SLA 或成本指标。
+- 先新增文档防漂移与 Netlify 安全头测试，基线得到 3 failed、12 passed；随后把当前操作流修订为“扫描业务异常 → 选择 case → 启动 Agent 调查 → 审批 → Verifier → 幂等工单/审计”，并为静态站补充 CSP、COOP、Permissions Policy、Referrer Policy、nosniff 和防 iframe 响应头。
+- GREEN 复验为发布/静态/索引契约 `18 passed`、文档索引 `115/115`、仓库安全通过；完整前端仍为 19 个测试文件/60 条用例，TypeScript/Vite production build 成功，产物指纹未变化。
+- 公网安全头要等 preview 与 production 部署后再次以真实 HTTP 响应验证；本地配置或测试通过不能写成已经上线。公网可写后端和生产治理仍需独立决策，production release gate 保持 `CLOSED`。

--- a/docs/development-log/daily/2026-07-30.md
+++ b/docs/development-log/daily/2026-07-30.md
@@ -111,3 +111,11 @@ GitHub compare API 证明 `1ff234c...main` 的净文件变化只有新增 `CONTR
 - 先新增文档防漂移与 Netlify 安全头测试，基线得到 3 failed、12 passed；随后把当前操作流修订为“扫描业务异常 → 选择 case → 启动 Agent 调查 → 审批 → Verifier → 幂等工单/审计”，并为静态站补充 CSP、COOP、Permissions Policy、Referrer Policy、nosniff 和防 iframe 响应头。
 - GREEN 复验为发布/静态/索引契约 `18 passed`、文档索引 `115/115`、仓库安全通过；完整前端仍为 19 个测试文件/60 条用例，TypeScript/Vite production build 成功，产物指纹未变化。
 - 公网安全头要等 preview 与 production 部署后再次以真实 HTTP 响应验证；本地配置或测试通过不能写成已经上线。公网可写后端和生产治理仍需独立决策，production release gate 保持 `CLOSED`。
+
+## Netlify 安全头 Preview 验证
+
+- 新电脑已重新连接 Netlify 站点 `opercerta-kxh`（site id：`c9a55c47-8ee1-4d38-be4d-aeb8355cfa74`），本机登录态仅由 Netlify CLI 管理，没有把 OAuth token 写入仓库或复制到 WSL。
+- Windows CLI 两次构建式 preview 因 Windows npm 与 WSL `node_modules` 的运行时边界失败，表现为 `tsc` 不可用；失败 deploy 为 `6a6b1742b0a84f106a2d6c02`、`6a6b17b006114307809dc315`，均未替换 production。
+- 改用已经在 WSL 完成 60 条前端测试和 production build 的 `web/dist` 做 `--no-build` preview，deploy `6a6b17cf496c38056f737264` 进入 ready。
+- Preview 的 `/`、`/console`、`/api/v1/auth/demo-token` 均返回 `200 text/html`；六项新增安全头全部存在，JS 大小和 SHA-256 与本地候选完全一致。
+- 本阶段只证明静态发布候选可回滚、可核验；production 尚未替换，公网业务后端仍未发布，产品 release gate 继续 `CLOSED`。

--- a/docs/learning/opercerta-interview-guide.md
+++ b/docs/learning/opercerta-interview-guide.md
@@ -2,7 +2,7 @@
 
 ## 30 秒版本
 
-“OperCerta 是我用 FastAPI、LangGraph、最小 LangChain、FastMCP、PostgreSQL/pgvector、Redis 和 React 实现的可恢复运营处置 Agent。它跑通库存补货、设备维修、作业异常恢复三条闭环：Plan-and-Execute Agent 受控取证，人工审批绑定快照，批准后重新复核，再幂等写工单。567 条后端测试、9/9 Agent 冻结评测和真实 Compose 重启证明本地可靠性；真实 Kimi Tool Calling 的新端到端路径目前未通过严格规划契约，我把它保留为兼容性问题，没有用 Mock 冒充。公网可写后端仍未上线。”
+“OperCerta 是我用 FastAPI、LangGraph、最小 LangChain、FastMCP、PostgreSQL/pgvector、Redis 和 React 实现的可恢复运营处置 Agent。它跑通库存补货、设备维修、作业异常恢复三条闭环：确定性检测先发现异常，Plan-and-Execute Agent 受控取证，人工审批绑定快照，批准后重新复核，再幂等写工单。最新 main 有 665 条后端测试、19 个前端测试文件/60 条用例、9/9 Agent 冻结评测和真实 Compose 重启证据；Real Kimi 的三业务只读、库存批准写入和无效 provider fail-closed 做过少量代表验证。公网可写后端仍未上线。”
 
 ## 3 分钟版本
 
@@ -11,7 +11,7 @@
 3. **可靠性：** 非法输入在边界失败；审批用行锁保证一个胜者；审批绑定包含证据/规则/事实/计划哈希；批准后绕过缓存重读 MCP；工单用确定性幂等键和唯一约束保证重放不多写。
 4. **恢复：** 业务 operation UUID 同时作为 LangGraph thread ID。启动扫描非终态业务表，再从 checkpoint 继续；业务表是真相，checkpoint 是执行进度。
 5. **证据：** 原三业务 42 条固定合成评测之外，新增 9 类 Agent 轨迹评测，覆盖非法 schema、提示注入、未知工具、对象漂移、RAG 隔离、审批后漂移、竞态、幂等和重启；Compose 使用真实 FastEmbed/pgvector RAG。
-6. **边界：** 本地 Mock Agent 闭环和真实 RAG 已验证；新 Agent 核心的 Kimi Tool Calling 集成未通过。生产 IAM、公开 HTTPS 后端、高可用和 Release Tag 尚未完成。
+6. **边界：** 本地 Mock 闭环、真实 RAG/数据库/MCP 和少量 Kimi 兼容路径已验证；真实调用样本不足以形成准确率、SLA 或成本结论。生产 IAM、公开 HTTPS 后端、高可用和 Release Tag 尚未完成。
 
 ## 10 分钟深挖提纲
 
@@ -69,11 +69,11 @@ request ID 和 W3C trace context 关联 API/MCP；span 跨 LangGraph、Redis、S
 
 这说明 Mock 用于确定性契约回归，Real 用于供应商协议兼容；两类证据都必要但不能互相替代。
 
-## 更新后的 30 秒讲法
+## 偏业务岗位的 30 秒讲法
 
 OperCerta 不是把聊天框贴到工单系统上，而是解决仓储异常调查跨系统、证据易过期、审批与执行容易脱节的问题。确定性监控先发现库存、设备和任务异常；单根 LangGraph 让 LLM 在受控 ToolPolicy 下通过 MCP 循环取证，结合 pgvector SOP 给建议，再由确定性规则和人工审批决定是否执行。批准后系统绕过 Redis 重新取证，由 Verifier 和审批 binding 双重校验，最后通过 PostgreSQL 唯一约束幂等写工单，并把 Trace、审计与恢复证据反馈到 React 工作台。
 
-## 更新后的 3 分钟讲法
+## 偏业务岗位的 3 分钟讲法
 
 先讲业务痛点：传统工单的难点不是表单录入，而是异常事实分散、调查步骤依赖经验、审批等待期间事实变化，以及重试可能重复落单。OperCerta 因此把“可解释调查”交给 LLM，把“能否写入”留给确定性安全内核。
 
@@ -104,11 +104,11 @@ OperCerta 不是把聊天框贴到工单系统上，而是解决仓储异常调�
 ## 面试现场演示顺序
 
 1. 先讲 30 秒架构和边界；
-2. 在同一页面做一次只读 query，说明零审批零工单；
-3. 做设备或作业创建处置，展示等待审批；
-4. 批准并展示唯一工单、审计和绑定；
+2. 点击“扫描业务异常”，解释 6 次只读 MCP 与确定性信号规则；
+3. 从设备或作业 case 点击“启动 Agent 调查”，展示 Goal、Tool/RAG、Trace 与等待审批；
+4. 批准并展示 Verifier、唯一工单、审计和绑定；
 5. 展示一个自动化测试或 42 条报告，而不是滚动大量终端；
-6. 主动说明真实模型只做过本地代表性验证，公网后端/生产 IAM 仍未完成。
+6. 主动说明三业务只读、库存批准写入和无效 provider fail-closed 只做过本地代表性验证，公网后端/生产 IAM 仍未完成。
 
 ## 个人掌握检查
 

--- a/docs/learning/opercerta-manual-experiment-guide.md
+++ b/docs/learning/opercerta-manual-experiment-guide.md
@@ -89,12 +89,12 @@ npm run dev
 
 打开 `http://127.0.0.1:5173/console`：
 
-1. 选择库存补货、设备维修或作业异常恢复；
-2. 先点“查询状态”，确认 `completed`、零审批、零工单；
-3. 点“创建处置”，确认进入 `awaiting_approval`；
-4. 切换 approver，核对 binding 后批准；
-5. 确认 `completed`、唯一工单和完整审计时间线；
-6. 再次审批，预期得到冲突而不是第二张工单。
+1. 保持 `operator`，点击“扫描业务异常”；首次点击会自动签发只保存在页面内存中的演示 JWT；
+2. 核对本次扫描范围、6 次只读 MCP 调用和三张合成业务 case；没有异常时不得创建处置；
+3. 选择一张状态为“待调查”的 case，点击“启动 Agent 调查”，确认 Goal、Tool/RAG 证据和 Trace 出现，并进入 `awaiting_approval`；
+4. 切换 `approver`，核对 binding 中的证据、规则版本、事实哈希、计划哈希和参数后批准；
+5. 确认 Verifier 已运行、处置为 `completed`、只有一张工单，并查看完整审计时间线；
+6. 切换 `auditor` 读取同一处置；重复审批预期得到冲突，而不是第二张工单。
 
 若审批窗口过期，控制台应显示“审批已过期”及重新创建处置的操作建议，而不是统一报“审批未提交”。这是安全终态：数据库保持零审批或零新工单，Trace run 结束而不是继续显示 `running`。
 
@@ -217,13 +217,13 @@ docker compose exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
 - **常见错误：** 首次机器没有 FastEmbed 缓存却强制 offline；此时先在获准网络下完成一次模型缓存，不要伪造向量。
 - **面试怎么讲：** “Mock 固定模型用于回归确定性，embedding 和数据库仍是真实组件；Real 模型另立报告。”
 
-### 步骤 2：operator 提交有限业务表单
+### 步骤 2：operator 从确定性异常信号启动有限调查
 
-- **输入：** 在 `http://127.0.0.1:5173/console` 选择 operator；任选 `SKU-LOW-001`、`EQ-PUMP-001`、`TASK-BLOCKED-001`，动作选“创建处置”。
+- **输入：** 在 `http://127.0.0.1:5173/console` 保持 operator，点击“扫描业务异常”；从 `SKU-LOW-001`、`EQ-PUMP-001`、`TASK-BLOCKED-001` 的异常 case 中选择一张，再点击“启动 Agent 调查”。
 - **预期：** 请求进入 `awaiting_approval`，页面出现结构化 Goal，而不是开放聊天回复。
-- **为什么：** 场景、动作和对象来自可信枚举，避免自由文本决定高风险写操作。
-- **常见错误：** 只输入 message 而未选对象；严格 API 会返回 422，且不应创建 operation。
-- **面试怎么讲：** “感知层接受有限表单，LLM 只编码受控目标，Harness 禁止对象漂移。”
+- **为什么：** 确定性检测先从业务事实产生信号，场景、动作和对象来自可信 case；LLM 只调查已确认异常，不负责猜测是否异常。
+- **常见错误：** 跳过 signal 直接请求生产写处置；严格 API 会返回 422，且不应创建 operation。
+- **面试怎么讲：** “感知层先用规则发现异常，再把有限 case 交给 LLM 编码 Goal，Harness 禁止对象漂移。”
 
 ### 步骤 3：查看 Goal、Tool、RAG 与 Observation
 
@@ -300,7 +300,7 @@ docker compose exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
 不要只背架构图。进入 WSL 工作树后，按一次真实请求的顺序阅读：
 
 ```bash
-cd /mnt/d/CODEX/agent-portfolio/opercerta/.worktrees/agent-core-implementation
+cd /mnt/d/CODEX/agent-portfolio/opercerta
 rg -n "ControlledAgentRootRunner|ControlledAgentRootRecoveryCoordinator" src/opercerta/api/app.py src/opercerta/application
 rg -n "model_decide|authorize_tools|execute_read_tools|approval_interrupt|verify_current_facts|execute_controlled_action" src/opercerta/workflow
 rg -n "class ToolPolicy|class ToolExecutor|class CachedReadToolGateway" src/opercerta
@@ -325,7 +325,7 @@ rg -n "create_or_get|FOR UPDATE|idempot" src/opercerta/infrastructure src/operce
 ```bash
 PYTHONPATH=.:src uv run pytest tests/unit -q
 PYTHONPATH=.:src uv run pytest tests/integration -q
-cd frontend && npm test -- --run && npm run build && cd ..
+cd web && npm run test:run && npm run build && cd ..
 docker compose up -d --build
 python3 scripts/verify_agent_compose.py
 docker compose restart api mcp

--- a/docs/release-evidence/github-actions-ci.md
+++ b/docs/release-evidence/github-actions-ci.md
@@ -1,5 +1,14 @@
 # GitHub Actions 分层 CI：远程验证证据
 
+## 2026-07-30 换机收口与最新 main 总门禁
+
+- [PR #15](https://github.com/KXHXK/opercerta/pull/15) 以普通 merge commit 合入 main `42ba9744ca91b4d6e2ade7dd81d6a7752ec40a1c`，未强推、未绕过检查。
+- 对应 [main run 30525556998](https://github.com/KXHXK/opercerta/actions/runs/30525556998) 的 `repository-safety`、`python-quality`、`frontend`、`backend-tests`、`compose-smoke` 五个 job 全部为 `success`。
+- 远程日志记录完整后端 `665 passed in 75.48s`；三业务契约评测 `1 passed`；冻结 Agent 安全/恢复评测 `9/9 passed`。前端为 19 个测试文件、60 条用例全部通过，Vite production build 成功。
+- `compose-smoke` 从隔离环境和新数据卷构建、启动服务，验证 Agent 轨迹与三业务数据库副作用，重启 API/MCP 后再验证恢复，最后无条件删除临时服务、网络和卷。
+- 本机随后 fast-forward 到同一 main，并在不删除原开发卷的前提下恢复 PostgreSQL、Redis、MCP、API 四服务；四者均 healthy，readiness 返回 database/checkpoint/MCP 全部 ready。
+- 以上证据关闭换机环境风险和单节点发布候选门禁；它不证明公网可写后端、生产 IAM、限流、备份、高可用或 SLA。
+
 ## 2026-07-27 PR #8 与 main 单根 Agent 总门禁
 
 - [PR #8](https://github.com/KXHXK/opercerta/pull/8) head `d22d247db2329f81f927866dde4ff3f59d5a2f8d` 在合并前状态为 `CLEAN`；PR run [30201946098](https://github.com/KXHXK/opercerta/actions/runs/30201946098) 的 `repository-safety`、`python-quality`、`backend-tests`、`frontend` 全部成功，`compose-smoke` 按 PR 条件跳过。

--- a/docs/release-evidence/public-portfolio-showcase.md
+++ b/docs/release-evidence/public-portfolio-showcase.md
@@ -1,5 +1,17 @@
 # OperCerta 公开专题部署证据
 
+## 2026-07-30 安全头发布候选 Preview
+
+- 候选分支：`chore/release-readiness-20260730`；候选源码提交：`4cd1e8563a2a8967775abc360ff2cd391b1012d5`。
+- 发布前门禁：发布/静态/索引定向契约 `18 passed`，文档索引 `115/115`，仓库安全扫描通过；前端 `19` 个测试文件、`60` 条用例通过，TypeScript/Vite production build 成功。
+- 新电脑首次执行 Windows `netlify deploy --build` 及 `--dir` 失败：Windows Netlify CLI 调用了 Windows npm，但 `web/node_modules` 由 WSL 安装，导致 `tsc` 不可用。失败 deploy 为 `6a6b1742b0a84f106a2d6c02`、`6a6b17b006114307809dc315`；它们未替换 production。
+- 修正方式不是复制 OAuth token 或重新生成未验证产物，而是复用已在 WSL 通过测试和构建的 `web/dist`，执行 `netlify deploy --dir web/dist --no-build`。
+- 成功 Preview deploy：`6a6b17cf496c38056f737264`；不可变地址：<https://6a6b17cf496c38056f737264--opercerta-kxh.netlify.app>。
+- 真实 HTTP 核验：`GET /`、`GET /console`、`GET /api/v1/auth/demo-token` 均为 `200 text/html`。第三项证明该站仍是 SPA 静态回退，没有伪装公开业务 API。
+- Preview 已实际返回 `Content-Security-Policy`、`Cross-Origin-Opener-Policy`、`Permissions-Policy`、`Referrer-Policy`、`X-Content-Type-Options` 和 `X-Frame-Options`；Preview 自带 `X-Robots-Tag: noindex`，符合预览环境预期。
+- 线上 JS 为 `index-Ckvsq13U.js`，大小 `254,845 bytes`，SHA-256 为 `dcd31a4d6e1c53f06c1a16cc6fb65f7f5d347926a078dc56fe08606c8052abb1`，与本地已验证产物完全一致。
+- 当前仅完成 Preview 验证，尚未替换 production。FastAPI、LangGraph、MCP、PostgreSQL、Redis 与模型密钥仍未部署到公网；OperCerta 原产品 release gate 保持 `CLOSED`。
+
 ## 2026-07-27 单根 Agent 版本生产替换
 
 - 对应源码合并提交：`609f8f7dcbfbadb9d12f4371cf49815d48884a4e`；PR：[KXHXK/opercerta#8](https://github.com/KXHXK/opercerta/pull/8)。

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,13 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    Cross-Origin-Opener-Policy = "same-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"

--- a/tests/unit/runtime/test_release_assets.py
+++ b/tests/unit/runtime/test_release_assets.py
@@ -155,7 +155,7 @@ def test_agent_delivery_documents_cover_architecture_learning_and_truthful_evide
     assert "Plan-and-Execute" in interview
     assert "六层 Agent" in interview
     assert "真实 Kimi Tool Calling" in interview
-    assert "未通过" in interview
+    assert "三业务只读、库存批准写入和无效 provider fail-closed" in interview
 
     for phrase in (
         "642d3ba",
@@ -168,3 +168,26 @@ def test_agent_delivery_documents_cover_architecture_learning_and_truthful_evide
         "CLOSED",
     ):
         assert phrase in evidence
+
+
+def test_current_demo_and_learning_docs_match_the_single_root_agent_release() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    demo = (ROOT / "docs" / "demo-script.md").read_text(encoding="utf-8")
+    manual = (ROOT / "docs" / "learning" / "opercerta-manual-experiment-guide.md").read_text(
+        encoding="utf-8"
+    )
+    interview = (ROOT / "docs" / "learning" / "opercerta-interview-guide.md").read_text(
+        encoding="utf-8"
+    )
+
+    for content in (demo, manual):
+        assert "扫描业务异常" in content
+        assert "启动 Agent 调查" in content
+    for content in (readme, demo, interview):
+        assert "三业务只读、库存批准写入和无效 provider fail-closed" in content
+        assert "新 Agent 核心的 Real Kimi Tool Calling 代表 query 为 failed" not in content
+
+    assert "665 条后端测试" in interview
+    assert ".worktrees/agent-core-implementation" not in manual
+    assert "cd frontend" not in manual
+    assert "cd web" in manual

--- a/tests/unit/runtime/test_static_hosting_assets.py
+++ b/tests/unit/runtime/test_static_hosting_assets.py
@@ -13,6 +13,20 @@ def test_netlify_build_is_static_and_supports_console_route() -> None:
     assert 'to = "/index.html"' in content
 
 
+def test_netlify_static_showcase_sets_browser_security_headers() -> None:
+    content = (ROOT / "netlify.toml").read_text(encoding="utf-8")
+
+    for header in (
+        "Content-Security-Policy",
+        "Cross-Origin-Opener-Policy",
+        "Permissions-Policy",
+        "Referrer-Policy",
+        "X-Content-Type-Options",
+        "X-Frame-Options",
+    ):
+        assert header in content
+
+
 def test_vite_local_proxy_targets_the_compose_api_port() -> None:
     content = (ROOT / "web" / "vite.config.ts").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 本轮范围
- 校正当前三业务 Agent 演示、核心手册与面试口径
- 为 Netlify 静态专题补充安全响应头及防漂移契约
- 记录换机环境、PR #15/main 门禁与可核验 Preview 证据

## 已验证
- 发布/静态/索引定向契约：18 passed
- 文档索引：115/115
- 仓库安全扫描：通过
- 前端：19 个测试文件、60 条用例通过，Vite production build 成功
- Netlify Preview：根页、/console 与 SPA API 回退均 200；六项安全头及 JS SHA-256 与本地候选一致

## 诚实边界
本 PR 只晋级静态求职展示，不发布公网 FastAPI、LangGraph、MCP、PostgreSQL、Redis 或模型密钥；OperCerta 原产品 production release gate 继续 CLOSED。