### PR TITLE
docs: record final showcase automation evidence

### DIFF
--- a/DOCUMENT_INDEX.md
+++ b/DOCUMENT_INDEX.md
@@ -27,7 +27,7 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 序号 | 文件名 | 路径 | 用途（详细） | 状态 | 日期 |
 | ---: | --- | --- | --- | --- | --- |
 | 1 | `README.md` | `README.md` | 英文项目总入口，使用顶部 `English｜简体中文` 标准链接切换语言，说明业务背景、三业务功能、Agent 闭环、完整技术栈、快速启动、使用流程、验证结果、可靠性边界和路线图。 | 每页只显示一种语言；不使用折叠框 | 2026-07-30 |
-| 2 | `IMPLEMENTATION_HANDOFF.md` | `IMPLEMENTATION_HANDOFF.md` | 跨对话和上下文压缩后的实施交接文件，记录当前分支、已验证事实、未完成事项、下一步动作及禁止越过的发布边界。 | 已切换为当前权威快照；Showcase 待本人验收，Product gate 关闭 | 2026-07-30 |
+| 2 | `IMPLEMENTATION_HANDOFF.md` | `IMPLEMENTATION_HANDOFF.md` | 跨对话和上下文压缩后的实施交接文件，记录当前分支、已验证事实、未完成事项、下一步动作及禁止越过的发布边界。 | PR #23/main 五项门禁已收口；Showcase 待本人验收，Product gate 关闭 | 2026-07-30 |
 | 3 | `DOCUMENT_INDEX.md` | `DOCUMENT_INDEX.md` | OperCerta 全部项目文档的唯一总登记表，用于按文件名、路径、用途、状态和日期统一检索、复查与交接。 | 当前根工作树 122 份文档已完整登记；另保留 6 个旧 worktree 的 456 条历史记录 | 2026-07-15 |
 | 4 | `2026-07-14-agent-project-naming-design.md` | `docs/specs/2026-07-14-agent-project-naming-design.md` | 定义 OperCerta、ForenTrail、SiteVerum、Federune 四个项目的命名原则、语义边界与品牌一致性，防止项目职责和名称漂移。 | 已冻结为命名基线 | 2026-07-14 |
 | 5 | `ai-agent-portfolio-overall-design.md` | `docs/specs/ai-agent-portfolio-overall-design.md` | 规定四个 AI Agent 项目的整体定位、差异化业务范围、技术能力组合、实施顺序和共同约束，是项目组合的最高层设计依据。 | 已冻结为总体设计基线；文件名已统一为英文路径 | 2026-07-14 |
@@ -68,7 +68,7 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 40 | `2026-07-20-opercerta-three-business-release.md` | `docs/superpowers/plans/2026-07-20-opercerta-three-business-release.md` | 将三业务适配、六个 MCP 工具、评测、Redis、OpenTelemetry、真实模型代表验证、本地发布和中文学习包拆成主线任务。 | 本地任务已执行；公网交互、用户掌握与最终门禁待完成 | 2026-07-20 |
 | 41 | `2026-07-20-opercerta-zero-cost-showcase-engineering-walkthrough.md` | `docs/superpowers/plans/2026-07-20-opercerta-zero-cost-showcase-engineering-walkthrough.md` | 规划统一事实清单、招聘专题、本地工程详解、控制台共存、响应式测试、静态导出和 Netlify 发布验证。 | 计划已创建；根分支尚未归档完成证据 | 2026-07-20 |
 | 42 | `README.md` | `docs/development-log/README.md` | 说明开发日志目录结构、各类日志职责、记录规范、敏感信息禁区和上下文恢复阅读顺序。 | 已建立并持续使用 | 2026-07-15 |
-| 43 | `current-state.md` | `docs/development-log/current-state.md` | 保存最新可验证项目状态、测试证据、运行环境、发布边界、未完成事项和下一步，作为压缩上下文后的唯一当前事实入口；历史状态只保留在 daily 与 release evidence。 | 工程门禁通过；Showcase 待本人验收；Product gate 关闭 | 2026-07-30 |
+| 43 | `current-state.md` | `docs/development-log/current-state.md` | 保存最新可验证项目状态、测试证据、运行环境、发布边界、未完成事项和下一步，作为压缩上下文后的唯一当前事实入口；历史状态只保留在 daily 与 release evidence。 | main `7bb9ecd` 五项门禁通过；Showcase 待本人验收；Product gate 关闭 | 2026-07-30 |
 | 44 | `2026-07-15.md` | `docs/development-log/daily/2026-07-15.md` | 记录日志体系、Windows PostgreSQL、审批领域契约及初始可靠性实施过程与命令证据。 | 当日记录已归档 | 2026-07-15 |
 | 45 | `2026-07-16.md` | `docs/development-log/daily/2026-07-16.md` | 记录库存补货 Task 1–9、幂等工单、LangGraph 恢复、调试过程和本地验证结果。 | 当日记录已归档 | 2026-07-16 |
 | 46 | `2026-07-17.md` | `docs/development-log/daily/2026-07-17.md` | 记录 WSL2、Docker Linux 运行时、JWT/RBAC 和 Compose 环境迁移中的问题、修复与验证。 | 当日记录已归档 | 2026-07-17 |
@@ -90,7 +90,7 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 62 | `cache-tracing-model-adapter.md` | `docs/release-evidence/cache-tracing-model-adapter.md` | 保存 Redis 只读缓存、审批后绕过、OpenTelemetry 脱敏关联、严格真实模型适配器及未验证边界的阶段证据。 | 阶段证据已归档；真实模型另有独立证据 | 2026-07-20 |
 | 63 | `demo-jwt-rbac.md` | `docs/release-evidence/demo-jwt-rbac.md` | 保存本地 JWT 签发、四角色权限矩阵、审批身份绑定、安全拒绝和 Compose 回归结果。 | 本地验证通过；不代表生产身份系统 | 2026-07-18 |
 | 64 | `docker-linux-runtime.md` | `docs/release-evidence/docker-linux-runtime.md` | 保存 WSL2 Ubuntu 下 Compose 构建、服务健康、数据库初始化、业务 smoke 和重启恢复的实际输出。 | 单节点本地验证通过；发布门禁仍关闭 | 2026-07-17 |
-| 65 | `github-actions-ci.md` | `docs/release-evidence/github-actions-ci.md` | 保存 GitHub PR/main Actions、后端与前端测试、PostgreSQL/Compose smoke、仓库可见性变化和分支保护能力核验。 | 已追加 PR #18、main run 30541088053、667/60/9-of-9、Compose 重启恢复与 Showcase 预发布证据；main 保护尚未配置 | 2026-07-30 |
+| 65 | `github-actions-ci.md` | `docs/release-evidence/github-actions-ci.md` | 保存 GitHub PR/main Actions、后端与前端测试、PostgreSQL/Compose smoke、仓库可见性变化和分支保护能力核验。 | 已追加 PR #23、main run 30629194460、671/60/9-of-9、uv 0.11.28 镜像构建与 Compose 重启恢复；main 保护尚未配置 | 2026-07-30 |
 | 66 | `inventory-replenishment-vertical-slice.md` | `docs/release-evidence/inventory-replenishment-vertical-slice.md` | 汇总库存查询、规则判断、审批、执行、唯一工单、审计和 API 的首条端到端后端闭环证据。 | Windows 本地后端闭环已验证；发布门禁仍关闭 | 2026-07-16 |
 | 67 | `langgraph-restart-recovery.md` | `docs/release-evidence/langgraph-restart-recovery.md` | 保存 LangGraph 四点 A/B 重启测试、checkpointer 状态、审批中断恢复和副作用不重复的数据库断言。 | 本地恢复证据已归档；不代表生产高可用 | 2026-07-16 |
 | 68 | `native-postgres-environment.md` | `docs/release-evidence/native-postgres-environment.md` | 保存 Windows 原生 PostgreSQL 版本、服务、数据库、角色、认证规则和连接验证结果。 | 历史环境证据已归档；当前主运行时已迁移 | 2026-07-15 |
@@ -141,8 +141,8 @@ Typora 显示：首次运行 `powershell -ExecutionPolicy Bypass -File scripts/i
 | 113 | `verifier-v1.md` | `src/opercerta/prompts/verifier-v1.md` | Verifier 角色版本化 Prompt，用于批准后重新核对事实、识别漂移并决定执行、重审批或安全终止。 | v1 已实施并有事实漂移回归测试 | 2026-07-21 |
 | 114 | `2026-07-30.md` | `docs/development-log/daily/2026-07-30.md` | 记录新电脑环境最终收口、WSL 登录 shell Node PATH 的 TDD 修复、冻结依赖国内镜像恢复、DrvFS 权限边界、PR/main 门禁，以及发布材料防漂移与静态安全头修订。 | PR #17/main 五项 CI、667/60/9-of-9、Netlify 静态 production 安全头与产物一致性均已验证 | 2026-07-30 |
 | 115 | `CONTRIBUTING.md` | `CONTRIBUTING.md` | 英文贡献指南，使用顶部 `English｜简体中文` 标准链接切换语言，规定开发环境、TDD 流程、Agent/业务安全规则、Python/前端/Compose 门禁、文档同步、PR 检查表和安全问题报告方式。 | 每页只显示一种语言；不使用折叠框 | 2026-07-30 |
-| 116 | `2026-07-31.md` | `docs/development-log/daily/2026-07-31.md` | 记录 OperCerta 最终 main/CI、Netlify 静态发布、Showcase 预发布、双语开源入口、规格一致性审计、自动化门禁、产品边界和下一掌握任务。 | 本地 Agent MVP 与静态展示已收口；公网交互和产品 production gate 保持 CLOSED | 2026-07-31 |
-| 117 | `2026-07-31-spec-release-readiness-audit.md` | `docs/development-log/audits/2026-07-31-spec-release-readiness-audit.md` | 对照四份原始设计及三业务、Agent 核心、信号收件箱和单根 LangGraph 有效修订，逐项核验当前源码、技术栈、测试、Compose、Netlify 和发布证据，区分合理设计演进、真实偏差、开源治理缺口、公网交互条件和简历可用边界。 | 审计完成；架构主线一致，本地/静态发布可用，公网交互与企业生产门禁未通过 | 2026-07-31 |
+| 116 | `2026-07-31.md` | `docs/development-log/daily/2026-07-31.md` | 记录 OperCerta 最终 main/CI、Netlify 静态发布、Showcase 预发布、双语开源入口、规格一致性审计、自动化门禁、产品边界和下一掌握任务。 | PR #23/main 自动化与 Compose 已收口；Showcase 等待本人验收和录屏 | 2026-07-31 |
+| 117 | `2026-07-31-spec-release-readiness-audit.md` | `docs/development-log/audits/2026-07-31-spec-release-readiness-audit.md` | 对照四份原始设计及三业务、Agent 核心、信号收件箱和单根 LangGraph 有效修订，逐项核验当前源码、技术栈、测试、Compose、Netlify 和发布证据，区分合理设计演进、真实偏差、开源治理缺口、公网交互条件和展示使用边界。 | main 自动化与 Compose 已通过；Showcase 等待本人验收，Product gate 关闭 | 2026-07-31 |
 | 118 | `README.zh-CN.md` | `README.zh-CN.md` | 简体中文项目总入口，与英文 README 保持等价结构和事实，使用顶部 `English｜简体中文` 链接切换语言，并独立展示中文业务、架构、启动、验证和边界内容。 | 每页只显示一种语言；不使用折叠框 | 2026-07-31 |
 | 119 | `CONTRIBUTING.zh-CN.md` | `CONTRIBUTING.zh-CN.md` | 简体中文贡献指南，与英文贡献指南保持等价结构和事实，使用顶部 `English｜简体中文` 链接切换语言。 | 每页只显示一种语言；不使用折叠框 | 2026-07-31 |
 | 120 | `2026-07-31-showcase-release-gate-amendment-design.md` | `docs/superpowers/specs/2026-07-31-showcase-release-gate-amendment-design.md` | 正式拆分 Showcase Release 与 Product Release，规定当前版本交付物为公开静态展示、本地可复现完整 Agent MVP、自动化证据、本人验收和录屏，并禁止把静态站点误报为公网交互产品。 | 已批准；Showcase 等待本人验收，Product gate 保持 CLOSED | 2026-07-31 |

--- a/IMPLEMENTATION_HANDOFF.md
+++ b/IMPLEMENTATION_HANDOFF.md
@@ -4,7 +4,7 @@
 
 ## 当前交接结论
 
-OperCerta 的代码与自动化主线已经完成，当前收口分支为 `release/showcase-ownership-closeout-20260731`。收口前最新 main 为 `61d5fa0`，由 PR #22 合入；main Actions run `30622621533` 五项全绿，包含后端 `668 passed`、前端 19 文件/60 条、三业务固定契约 42/42、Agent 安全恢复 9/9 和真实 Compose 重启恢复。本分支增加 3 条发布/安全契约后，本地专用 pgvector 测试库完整结果为 `671 passed`。
+OperCerta 的代码与自动化主线已经完成。双门禁与本人掌握收口经 PR #23 合入 main `7bb9ecda8170ed8752049331f5597ea2368d77b1`；main Actions run `30629194460` 五项全绿，包含后端 `671 passed`、前端 19 文件/60 条、三业务固定契约 42/42、Agent 安全恢复 9/9，以及干净构建 uv `0.11.28` 镜像后的真实 Compose 三业务数据库副作用与 API/MCP 重启恢复。
 
 本版本发布定义已经正式修订为：
 
@@ -35,11 +35,9 @@ OperCerta 的代码与自动化主线已经完成，当前收口分支为 `relea
 
 ## 下一执行顺序
 
-1. 跑定向门禁与完整 Python/前端/Compose 检查。
-2. 提交、推送、创建 PR，等待所有检查通过后合入 main。
-3. 在 main 上复跑 Compose smoke，更新最终提交、run 和测试数字。
-4. 由项目所有者亲自执行 `docs/learning/opercerta-ownership-acceptance.md`；必须记录 `operation_id`、`work_order_id`、Trace、审计序列和数据库事实，**不得由 Codex 自动代签**。
-5. 完成 3–5 分钟录屏与口述复盘后，才能把 Showcase 门禁改为 `PASSED` 并创建最终 tag。
+1. 由项目所有者亲自执行 `docs/learning/opercerta-ownership-acceptance.md`；必须记录 `operation_id`、`work_order_id`、Trace、审计序列和数据库事实，**不得由 Codex 自动代签**。
+2. 完成 3–5 分钟录屏与口述复盘。
+3. 人工证据通过后，把 Showcase 门禁改为 `PASSED`，创建最终 tag 并记录回滚提交。
 
 ## 本地运行入口
 

--- a/docs/development-log/audits/2026-07-31-spec-release-readiness-audit.md
+++ b/docs/development-log/audits/2026-07-31-spec-release-readiness-audit.md
@@ -14,7 +14,7 @@ OperCerta 当前实现与“受控单 Agent + 三业务共享可靠性内核”�
 
 | 门禁 | 状态 | 剩余条件 |
 | --- | --- | --- |
-| 工程与本地自动化 | `PASSED` | 本收口分支合并后补录新鲜 main CI/Compose 结果 |
+| 工程与本地自动化 | `PASSED` | PR #23、main `7bb9ecd`、run `30629194460` 五项全绿 |
 | Showcase Release | `AWAITING_OWNER_VALIDATION` | 本人完整实演、源码讲解、恢复/幂等验证和录屏 |
 | Product Release | `CLOSED` | 公网可写后端及完整生产治理未实现 |
 
@@ -44,7 +44,7 @@ OperCerta 当前实现与“受控单 Agent + 三业务共享可靠性内核”�
 | 前后端 | FastAPI 安全边界、React Case 工作台、SSE/Trace/审计 | 本地一致；公网 API 未部署 |
 | 基础设施 | PostgreSQL 18/pgvector、Redis、Docker Compose、Caddy | 本地与 CI 一致 |
 | 可观测性 | 关联 ID、结构化日志、OpenTelemetry、Prometheus | 代码/测试具备；无公网 collector/dashboard |
-| 测试评测 | 本分支后端 671、前端 60、三业务 42/42、Agent 9/9、Compose | 后端为一次性 pgvector 库本地结果；最终 main 仍需 CI 复核；不是生产 SLA |
+| 测试评测 | 后端 671、前端 60、三业务 42/42、Agent 9/9、Compose | 本地与 main CI 已复核；不是生产 SLA |
 
 ## 合理设计演进
 
@@ -55,8 +55,9 @@ OperCerta 当前实现与“受控单 Agent + 三业务共享可靠性内核”�
 
 ## 已验证事实
 
-- 收口前最新 main 为 `61d5fa0`，PR #22 和 Actions run `30622621533` 五项成功。
-- 收口前 main 为后端 668；本分支新增 3 条门禁契约后，本地一次性 pgvector 测试库结果为 `671 passed in 112.07s`。前端 19 文件/60 条、三业务 42/42、Agent 9/9、Compose 数据库副作用及 API/MCP 重启恢复此前均通过，等待本分支最终复验。
+- PR #23 已合入 main `7bb9ecda8170ed8752049331f5597ea2368d77b1`；Actions run `30629194460` 五项成功。
+- 本轮新增 3 条门禁契约后，本地一次性 pgvector 测试库为 `671 passed in 112.07s`；main backend job 再次通过。前端 19 文件/60 条、三业务 42/42、Agent 9/9 均通过。
+- main Compose 在干净 GitHub Linux 环境成功构建 uv `0.11.28` 镜像，完成三业务数据库副作用、API/MCP 重启、恢复和清理；本机 GHCR 拉取超时不再构成未验证缺口。
 - Netlify 根路径与 `/api/*` 都是静态 SPA，证明公网未暴露 FastAPI。
 - 本机 `opercerta-demo` 的 PostgreSQL、Redis、MCP、API 四服务 healthy，readiness 的 database/checkpoint/MCP 均 ready。
 - README/CONTRIBUTING 使用标准 `English｜简体中文` 双文件互链；GitHub Markdown 不支持无跳转、无折叠且只显示一种语言的自定义状态切换。
@@ -91,8 +92,7 @@ OperCerta 当前实现与“受控单 Agent + 三业务共享可靠性内核”�
 
 ## 剩余 P0 收口
 
-1. 本分支全门禁、PR、main CI 与 Compose 复验。
-2. 项目所有者按 `docs/learning/opercerta-ownership-acceptance.md` 独立完成验收，并保存 `operation_id`、`work_order_id`、Trace、审计和数据库事实。
-3. 完成 3–5 分钟录屏；之后才能签署本人掌握结果并创建最终 Showcase tag。
+1. 项目所有者按 `docs/learning/opercerta-ownership-acceptance.md` 独立完成验收，并保存 `operation_id`、`work_order_id`、Trace、审计和数据库事实。
+2. 完成 3–5 分钟录屏；之后才能签署本人掌握结果并创建最终 Showcase tag。
 
 ForenTrail 暂不启动。FieldPilot 在 OperCerta 完成后另行规划，不混入本仓库。

--- a/docs/development-log/current-state.md
+++ b/docs/development-log/current-state.md
@@ -14,7 +14,7 @@ OperCerta 的三业务共享 Agent 主线、可靠性内核、前后端、本地
 
 | 门禁 | 状态 | 判定依据 |
 | --- | --- | --- |
-| 工程与本地自动化门禁 | `PASSED` | 当前 main `61d5fa0`；PR #22 合并；main run `30622621533` 五项成功；本分支本地后端 671；前端 60、三业务 42/42、Agent 9/9、Compose 重启恢复通过 |
+| 工程与本地自动化门禁 | `PASSED` | 当前 main `7bb9ecd`；PR #23 合并；main run `30629194460` 五项成功；后端 671、前端 60、三业务 42/42、Agent 9/9、Compose 重启恢复通过 |
 | Showcase Release gate | `AWAITING_OWNER_VALIDATION` | 静态站点和本地 MVP 已具备；仍需项目所有者独立完成业务实演、源码讲解、恢复实验和录屏 |
 | Product Release gate | `CLOSED` | 未部署公网可写后端、生产身份、限流、防滥用、托管数据库备份、高可用与线上告警 |
 
@@ -22,7 +22,7 @@ OperCerta 的三业务共享 Agent 主线、可靠性内核、前后端、本地
 
 `Product Release gate: CLOSED`
 
-最新 main 的后端基线为 668；本分支新增 3 条发布/安全契约后，使用一次性 pgvector 测试库得到 `671 passed in 112.07s`。合并后仍须用最终 main CI 复核该数字。
+本分支新增 3 条发布/安全契约后，本地一次性 pgvector 测试库得到 `671 passed in 112.07s`；main backend job 随后复核通过。
 
 ## 已实现范围
 
@@ -38,8 +38,9 @@ OperCerta 的三业务共享 Agent 主线、可靠性内核、前后端、本地
 
 ## 当前运行与发布证据
 
-- GitHub main：`61d5fa0`；PR #22；Actions run `30622621533` 五项全绿。
-- 自动化基线：本分支本地后端 `671 passed`；前端 19 文件/60 条；三业务固定契约 42/42；冻结 Agent 安全恢复 9/9；收口前 main Compose smoke 通过。
+- GitHub main：`7bb9ecda8170ed8752049331f5597ea2368d77b1`；PR #23；Actions run `30629194460` 五项全绿。
+- 自动化基线：后端 `671 passed`；前端 19 文件/60 条；三业务固定契约 42/42；冻结 Agent 安全恢复 9/9；main Compose smoke 通过。
+- main Compose 在干净 GitHub Linux 环境构建 uv `0.11.28` 镜像，验证三业务数据库副作用、API/MCP 重启、恢复和隔离卷清理，关闭了本机 GHCR 拉取超时留下的容器证据缺口。
 - 本机 WSL2 Ubuntu 26.04 的 `opercerta-demo` PostgreSQL、Redis、MCP、API 四服务 healthy；readiness 中 database、checkpoint、MCP 均 ready。
 - Netlify 为静态站点；`/console` 与 `/api/*` 在公网均是 SPA 静态回退，不是可写后端。
 - 旧预发布 `v0.1.0-showcase.1` 指向较早提交，只保留历史；最终 Showcase tag 必须在本轮合并、本人验收和录屏后创建。

--- a/docs/development-log/daily/2026-07-31.md
+++ b/docs/development-log/daily/2026-07-31.md
@@ -70,4 +70,6 @@
 - 定向发布契约 `30 passed`；Ruff、216 文件格式、mypy 85 个源码文件、仓库安全和 122 份文档索引均通过；使用仅绑定 `127.0.0.1:55432`、退出自动删除的一次性 pgvector PostgreSQL 运行完整后端，结果为 `671 passed in 112.07s`。
 - 三业务固定评测脚本通过（pytest wrapper `1 passed`），冻结 Agent 安全/恢复评测 `9/9`；前端 19 文件/60 条和 Vite production build 通过。
 - 本机重建应用镜像等待 `ghcr.io/astral-sh/uv:0.11.28` 层超过 5 分钟后超时，本地未缓存该镜像，未把本次容器构建记为通过；最终容器结论必须来自合并后 GitHub main-only Compose smoke。
+- Git smart-HTTP 因当前网络对 `github.com:443` 的 TLS/连接重置连续失败；改用 GitHub Git Data API 上传 16 个提交文件，只有远端 tree SHA `4081242d4c07918267fb45950c3eb0e8ab882e6f` 与本地提交树完全一致后才创建分支，避免静默内容偏差。
+- [PR #23](https://github.com/KXHXK/opercerta/pull/23) 四项 PR 门禁全绿后普通合入 main `7bb9ecda8170ed8752049331f5597ea2368d77b1`；[main run 30629194460](https://github.com/KXHXK/opercerta/actions/runs/30629194460) 五项全绿。Compose 在 GitHub 干净 Linux 环境构建 uv `0.11.28` 镜像，并完成三业务数据库副作用、API/MCP 重启、恢复和清理，因此本机 GHCR 超时的容器证据缺口已关闭。
 - ForenTrail 暂不启动；FieldPilot 在 OperCerta 完成并真正掌握后另行推进，不混入本仓库。

--- a/docs/release-evidence/github-actions-ci.md
+++ b/docs/release-evidence/github-actions-ci.md
@@ -1,5 +1,15 @@
 # GitHub Actions 分层 CI：远程验证证据
 
+## 2026-07-31 双门禁收口 PR #23 与 main 总门禁
+
+- [PR #23](https://github.com/KXHXK/opercerta/pull/23) 的 `repository-safety`、`python-quality`、`backend-tests`、`frontend` 全部成功，`compose-smoke` 按 PR 事件规则跳过；随后以普通 merge commit `7bb9ecda8170ed8752049331f5597ea2368d77b1` 合入 main。
+- 对应 [main run 30629194460](https://github.com/KXHXK/opercerta/actions/runs/30629194460) 五项 job 全部为 `success`。
+- `backend-tests` 通过完整 671 条后端测试、三业务固定契约和冻结 Agent 安全/恢复评测 `9/9`；`frontend` 通过 19 个测试文件/60 条用例和 Vite production build。
+- `python-quality` 通过 Ruff、format 与 mypy；`repository-safety` 通过双语公开文档凭据扫描、固定 Action 和权限边界检查。
+- `compose-smoke` 在干净 GitHub Linux 环境使用 Dockerfile 固定的 uv `0.11.28` 构建镜像，启动 PostgreSQL、Redis、MCP 和 API，验证三业务 Agent 轨迹与数据库副作用，重启 API/MCP 后完成 recovery-only 验证，并删除隔离资源。
+- 本次远程结果关闭本机 GHCR 拉取超时导致的容器构建证据缺口。它证明本地可复现单节点 Agent MVP，不证明公网交互、生产 IAM、高可用或 SLA。
+- 当前 `Showcase Release gate: AWAITING_OWNER_VALIDATION`；`Product Release gate: CLOSED`。
+
 ## 2026-07-31 最终证据合并与 Showcase Pre-release
 
 - [PR #18](https://github.com/KXHXK/opercerta/pull/18) 已合入 main `298fc5978a56961d36e73888f4ae73017e302715`，未绕过检查。

--- a/tests/unit/runtime/test_release_assets.py
+++ b/tests/unit/runtime/test_release_assets.py
@@ -285,7 +285,8 @@ def test_showcase_release_gate_and_owner_acceptance_are_explicit() -> None:
         assert phrase in amendment
     assert "Showcase Release gate: AWAITING_OWNER_VALIDATION" in state
     assert "Product Release gate: CLOSED" in state
-    assert "PR #22" in handoff
+    assert "PR #23" in handoff
+    assert "30629194460" in handoff
     assert "671 passed" in handoff
     assert "不得由 Codex 自动代签" in ownership
     assert "operation_id" in ownership


### PR DESCRIPTION
## What changed

- Record PR #23, main merge `7bb9ecd`, and main run `30629194460` as the current authoritative automation evidence.
- Update the handoff, current state, release audit, daily log, CI evidence, and document index.
- Record that the clean main Compose job built the uv 0.11.28 image and passed three-business effects plus API/MCP restart recovery.
- Keep Showcase awaiting owner validation and Product Release closed.

## Validation

- Release/document contract tests: 16 passed.
- Repository safety: passed.
- Document index: 122 current Markdown files, passed.
- `git diff --check`: passed.

This PR changes evidence and its drift contract only; it does not change the Agent runtime or public deployment boundary.
